### PR TITLE
LeNet: add custom Subsampling layer from the paper

### DIFF
--- a/lenet/LeNet_with_Subsampling_in_Keras.ipynb
+++ b/lenet/LeNet_with_Subsampling_in_Keras.ipynb
@@ -1,0 +1,499 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "# Copyright 2022 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#      http://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "metadata": {
+        "id": "-52CicmjShjz"
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "OfRXb7AXBNoB"
+      },
+      "outputs": [],
+      "source": [
+        "from math import ceil\n",
+        "from typing import Callable, Optional, List, Tuple, Union\n",
+        "\n",
+        "import numpy as np\n",
+        "\n",
+        "import tensorflow as tf\n",
+        "from tensorflow import keras\n",
+        "from keras import Input, Sequential\n",
+        "from keras.layers import AveragePooling2D, Conv2D, Dense, Flatten, Layer"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "rEBeAvrWBQCU"
+      },
+      "outputs": [],
+      "source": [
+        "# Load the MNIST dataset.\n",
+        "(x_train_raw, y_train_raw), (x_test_raw, y_test_raw) = tf.keras.datasets.mnist.load_data()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Examine the dataset shape.\n",
+        "print(\"Raw data:\")\n",
+        "print(f\"Train x: {x_train_raw.shape}\")\n",
+        "print(f\"      y: {y_train_raw.shape}\")\n",
+        "print(f\"Test  x: {x_test_raw.shape}\")\n",
+        "print(f\"      y: {y_test_raw.shape}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "L9SC3sIaDv_i",
+        "outputId": "9c3a7e32-ceaa-48aa-8722-4144b824f511"
+      },
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Raw data:\n",
+            "Train x: (60000, 28, 28)\n",
+            "      y: (60000,)\n",
+            "Test  x: (10000, 28, 28)\n",
+            "      y: (10000,)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "num_classes = 10\n",
+        "\n",
+        "# Expand the dimensions of our inputs to ensure their shape is (28, 28, 1),\n",
+        "# rather than (28, 28) which is what they are by default.\n",
+        "x_train = np.expand_dims(x_train_raw, -1)\n",
+        "x_test = np.expand_dims(x_test_raw, -1)\n",
+        "\n",
+        "# Scale train and test inputs by converting them from range of [0, 255] to [0.0, 1.0]\n",
+        "x_train = x_train_raw.astype('float32') / 255.0\n",
+        "x_test = x_test_raw.astype('float32') / 255.0\n",
+        "\n",
+        "# Convert the output to categorical one-hot encoding to match the output of our\n",
+        "# network.\n",
+        "y_train = keras.utils.to_categorical(y_train_raw, num_classes)\n",
+        "y_test = keras.utils.to_categorical(y_test_raw, num_classes)\n",
+        "\n",
+        "print(\"\\nProcessed data:\")\n",
+        "print(f\"Train x: {x_train.shape}\")\n",
+        "print(f\"      y: {y_train.shape}\")\n",
+        "print(f\"Test  x: {x_test.shape}\")\n",
+        "print(f\"      y: {y_test.shape}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "mhnNc_LSAoWh",
+        "outputId": "79c07b44-baf6-4062-99be-a667c6e80177"
+      },
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "Processed data:\n",
+            "Train x: (60000, 28, 28)\n",
+            "      y: (60000, 10)\n",
+            "Test  x: (10000, 28, 28)\n",
+            "      y: (10000, 10)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "id": "6oCDY6OEDrOp",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "5bd9c85d-2a63-4434-f605-03fceda823fd"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Y values before preprocessing:\n",
+            "[5 0 4 1]\n",
+            "\n",
+            "Y values after preprocessing:\n",
+            "[[0. 0. 0. 0. 0. 1. 0. 0. 0. 0.]\n",
+            " [1. 0. 0. 0. 0. 0. 0. 0. 0. 0.]\n",
+            " [0. 0. 0. 0. 1. 0. 0. 0. 0. 0.]\n",
+            " [0. 1. 0. 0. 0. 0. 0. 0. 0. 0.]]\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Examine the format of the Y values before and after preprocessing.\n",
+        "print('Y values before preprocessing:')\n",
+        "print(y_train_raw[0:4])\n",
+        "\n",
+        "print('\\nY values after preprocessing:')\n",
+        "print(y_train[0:4])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class SubsamplingArgumentError(ValueError):\n",
+        "    pass\n",
+        "\n",
+        "class Subsampling(Layer):\n",
+        "    pool_size: Tuple[int, int]\n",
+        "    strides: Tuple[int, int]\n",
+        "    padding: str\n",
+        "    activation: Callable[[float], float]\n",
+        "    w: np.array\n",
+        "    b: np.array\n",
+        "\n",
+        "    def __init__(\n",
+        "        self,\n",
+        "        pool_size: Union[int, List[int], Tuple[int, int]] = (2, 2),\n",
+        "        strides: Optional[Union[int, List[int], Tuple[int, int]]] = None,\n",
+        "        padding: str = 'VALID',\n",
+        "        activation: Callable[[float], float] = None,\n",
+        "        **kwargs):\n",
+        "        \"\"\"Subsampling layer as described in the LeNet paper.\n",
+        "\n",
+        "        This layer is not a simple average or max pooling that are typically\n",
+        "        used to implement LeNet: neither average-pooling nor max-pooling have\n",
+        "        any trainable parameters, while the subsampling layer described in the\n",
+        "        LeNet paper *does* have trainable parameters.\n",
+        "\n",
+        "        Note: assumes data format is `(batch_size, rows, cols, channels)`, i.e.,\n",
+        "        what TensorFlow / Keras describe as \"channels_last\".\n",
+        "\n",
+        "        Args:\n",
+        "          pool_size: int or 2-tuple specifying pool size (aka kernel size)\n",
+        "          strides: int or 2-tuple; if unspecified, will be copied from\n",
+        "            `pool_size`\n",
+        "          padding:\n",
+        "        \"\"\"\n",
+        "        super().__init__(**kwargs)\n",
+        "\n",
+        "        if isinstance(pool_size, int):\n",
+        "            self.pool_size = (pool_size, pool_size)\n",
+        "        elif (isinstance(pool_size, list) or isinstance(pool_size, tuple)) and \\\n",
+        "            len(pool_size) == 2:\n",
+        "            self.pool_size = tuple(pool_size)\n",
+        "        else:\n",
+        "            raise SubsamplingArgumentError(\n",
+        "                f\"`pool_size` must be an int or 2-tuple; received: {pool_size}\")\n",
+        "\n",
+        "        if strides is None:\n",
+        "            self.strides == self.pool_size\n",
+        "        elif isinstance(strides, int):\n",
+        "            self.strides = (strides, strides)\n",
+        "        elif (isinstance(strides, list) or isinstance(strides, tuple)) and \\\n",
+        "            len(strides) == 2:\n",
+        "            self.strides = tuple(strides)\n",
+        "        else:\n",
+        "            raise SubsamplingArgumentError(\n",
+        "                f\"`strides` must be an int or 2-tuple; received: {strides}\")\n",
+        "\n",
+        "        assert padding is not None and padding.upper() in ('VALID', 'SAME'), (\n",
+        "            f\"`padding` must be either 'VALID' or 'SAME'; received: {padding}\")\n",
+        "        self.padding = padding.upper()\n",
+        "\n",
+        "        self.activation = activation or (lambda x: x)\n",
+        "        \n",
+        "    def build(\n",
+        "        self, input_shape: Union[List[Optional[int]],\n",
+        "                                 Tuple[Optional[int], int, int, int]]) -> None:\n",
+        "        \"\"\"Builds internal structures to prepare for model training.\n",
+        "        \n",
+        "        Args:\n",
+        "          input_shape: length-4 list or tuple representing (batch_size, rows,\n",
+        "            cols, channels); where `batch_size` may be None; see docs above for\n",
+        "            `__init__()` for details.\n",
+        "        \"\"\"\n",
+        "        if len(input_shape) != 4:\n",
+        "            raise SubsamplingArgumentError(\n",
+        "                f\"`len(input_shape)` != 4; received: {input_shape}\")\n",
+        "        if input_shape[0] is not None:\n",
+        "            raise SubsamplingArgumentError(\n",
+        "                f\"`input_shape[0] must be None; received: {input_shape}\")\n",
+        "\n",
+        "        in_chan = input_shape[3]\n",
+        "\n",
+        "        self.w = self.add_weight(shape=(1, 1, in_chan),\n",
+        "                                 initializer=\"random_normal\",\n",
+        "                                 trainable=True)\n",
+        "\n",
+        "        self.b = self.add_weight(shape=(1, 1, in_chan),\n",
+        "                                 initializer=\"random_normal\",\n",
+        "                                 trainable=True)\n",
+        "\n",
+        "    def call(self, inputs: tf.Tensor) -> tf.Tensor:\n",
+        "        \"\"\"Computes subsampling value: `w * (sum of window entries) + b`.\"\"\"\n",
+        "\n",
+        "        # `scale` here undoes the average pooling by getting the original sum,\n",
+        "        # which is what we need, but there isn't a pooling mechanism that just\n",
+        "        # gets us the sum of products.\n",
+        "        scale = self.pool_size[0] * self.pool_size[1]\n",
+        "        tf_scale = tf.constant(scale, dtype='float32')\n",
+        "\n",
+        "        avg = tf.nn.pool(inputs,\n",
+        "                         window_shape=self.pool_size,\n",
+        "                         pooling_type='AVG',\n",
+        "                         strides=self.strides,\n",
+        "                         padding=self.padding)\n",
+        "\n",
+        "        return self.activation(self.w * tf_scale * avg + self.b)"
+      ],
+      "metadata": {
+        "id": "sd1N_-7VHxLY"
+      },
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def lenet_activation(a: float) -> float:\n",
+        "    A = 1.7159\n",
+        "    S = 2. / 3\n",
+        "    return A * keras.activations.tanh(S * a)"
+      ],
+      "metadata": {
+        "id": "rSmV5tE911bM"
+      },
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "eptAFMyWBD8L",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "a5db8a93-0352-4321-cd45-43116cb44879"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model: \"LeNet-5\"\n",
+            "_________________________________________________________________\n",
+            " Layer (type)                Output Shape              Param #   \n",
+            "=================================================================\n",
+            " C1 (Conv2D)                 (None, 28, 28, 6)         156       \n",
+            "                                                                 \n",
+            " S2 (Subsampling)            (None, 14, 14, 6)         12        \n",
+            "                                                                 \n",
+            " C3 (Conv2D)                 (None, 10, 10, 16)        2416      \n",
+            "                                                                 \n",
+            " S4 (Subsampling)            (None, 5, 5, 16)          32        \n",
+            "                                                                 \n",
+            " flatten (Flatten)           (None, 400)               0         \n",
+            "                                                                 \n",
+            " C5 (Dense)                  (None, 120)               48120     \n",
+            "                                                                 \n",
+            " F6 (Dense)                  (None, 84)                10164     \n",
+            "                                                                 \n",
+            " Output (Dense)              (None, 10)                850       \n",
+            "                                                                 \n",
+            "=================================================================\n",
+            "Total params: 61,750\n",
+            "Trainable params: 61,750\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n"
+          ]
+        }
+      ],
+      "source": [
+        "model = Sequential([\n",
+        "    Input(shape=(28, 28, 1)),\n",
+        "    Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=lenet_activation, name=\"C1\"),\n",
+        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=lenet_activation, name=\"S2\"),\n",
+        "    Conv2D(filters=16, kernel_size=(5, 5), activation=lenet_activation, name=\"C3\"),\n",
+        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=lenet_activation, name=\"S4\"),\n",
+        "    Flatten(),\n",
+        "    Dense(120, activation=lenet_activation, name=\"C5\"),\n",
+        "    Dense(84, activation=lenet_activation, name=\"F6\"),\n",
+        "    Dense(10, activation='softmax', name=\"Output\"),\n",
+        "], name=\"LeNet-5\")\n",
+        "\n",
+        "model.summary()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Compile the model with optimizer and loss function.\n",
+        "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
+        "loss_fn = keras.losses.CategoricalCrossentropy()\n",
+        "model.compile(optimizer=opt, loss=loss_fn, metrics=['accuracy'])"
+      ],
+      "metadata": {
+        "id": "BenA0xmJA9_f"
+      },
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "UM_tm3UfBSt9",
+        "outputId": "e9a470d4-0de4-4499-91c9-cdfe056e8f4c"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Epoch 1/20\n",
+            "1875/1875 [==============================] - 18s 6ms/step - loss: 0.2624 - accuracy: 0.9194\n",
+            "Epoch 2/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0950 - accuracy: 0.9710\n",
+            "Epoch 3/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0619 - accuracy: 0.9808\n",
+            "Epoch 4/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0489 - accuracy: 0.9847\n",
+            "Epoch 5/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0386 - accuracy: 0.9876\n",
+            "Epoch 6/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0334 - accuracy: 0.9893\n",
+            "Epoch 7/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0268 - accuracy: 0.9913\n",
+            "Epoch 8/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0232 - accuracy: 0.9925\n",
+            "Epoch 9/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0197 - accuracy: 0.9935\n",
+            "Epoch 10/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0186 - accuracy: 0.9936\n",
+            "Epoch 11/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0172 - accuracy: 0.9943\n",
+            "Epoch 12/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0136 - accuracy: 0.9954\n",
+            "Epoch 13/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0127 - accuracy: 0.9955\n",
+            "Epoch 14/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0139 - accuracy: 0.9951\n",
+            "Epoch 15/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0104 - accuracy: 0.9967\n",
+            "Epoch 16/20\n",
+            "1875/1875 [==============================] - 8s 4ms/step - loss: 0.0124 - accuracy: 0.9955\n",
+            "Epoch 17/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0093 - accuracy: 0.9969\n",
+            "Epoch 18/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0101 - accuracy: 0.9968\n",
+            "Epoch 19/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0100 - accuracy: 0.9966\n",
+            "Epoch 20/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0101 - accuracy: 0.9965\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<keras.callbacks.History at 0x7f7d50577f10>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 11
+        }
+      ],
+      "source": [
+        "# Train the model\n",
+        "model.fit(x_train, y_train, epochs=20)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Evaluate the model\n",
+        "model.evaluate(x_test, y_test)"
+      ],
+      "metadata": {
+        "id": "-oORwhVmEbV_",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "0295e999-5d1c-44a8-d3ea-add07e3d0792"
+      },
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "313/313 [==============================] - 1s 3ms/step - loss: 0.0566 - accuracy: 0.9860\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[0.05663033574819565, 0.9860000014305115]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 12
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "LeNet with Subsampling in Keras",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/lenet/README.md
+++ b/lenet/README.md
@@ -6,9 +6,10 @@ dataset.
 
 Available implementations:
 
-| Implementation | GitHub preview<br/>(readonly) | Colab | Binder |
-| -------------- | ----------------------------- | ----- | ------ |
-| Basic | [GitHub][github-basic] | [![Open In Colab][colab-badge]][colab-basic] | [![Open in Binder][binder-badge]][binder-basic] |
+| Implementation | Library | GitHub preview<br/>(readonly) | Colab | Binder |
+| -------------- | ------- | ----------------------------- | ----- | ------ |
+| Basic impl using MaxPool2D and ReLU | Keras | [GitHub][github-basic] | [![Open In Colab][colab-badge]][colab-basic] | [![Open in Binder][binder-badge]][binder-basic] |
+| Subsampling layer + LeNet activation | Keras | [GitHub][github-subsampling] | [![Open In Colab][colab-badge]][colab-subsampling] | [![Open in Binder][binder-badge]][binder-subsampling] |
 
 Our implementation is based on the following paper:
 
@@ -29,7 +30,13 @@ See also:
 
 [colab-badge]: https://colab.research.google.com/assets/colab-badge.svg
 [binder-badge]: https://static.mybinder.org/badge_logo.svg
+
 [github-basic]: Basic_LeNet_in_Keras.ipynb
 [colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/Basic_LeNet_in_Keras.ipynb
 [binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/Basic_LeNet_in_Keras.ipynb
+
+[github-subsampling]: LeNet_with_Subsampling_in_Keras.ipynb
+[colab-subsampling]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_with_Subsampling_in_Keras.ipynb
+[binder-subsampling]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_with_Subsampling_in_Keras.ipynb
+
 [lenet-google-scholar]: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=WLN3QrAAAAAJ&citation_for_view=WLN3QrAAAAAJ:u5HHmVD_uO8C


### PR DESCRIPTION
Although our basic implementation uses MaxPool2D layer, the paper actually
defines its own Subsampling layer, which has trainable parameters, unlike
MaxPool2D, which has none.

We also introduce the custom activation function from the paper rather than
using ReLU as was done in the basic implementation.