### PR TITLE
Remove imports only needed for Subsampling layer

### DIFF
--- a/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+++ b/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
@@ -31,15 +31,12 @@
       },
       "outputs": [],
       "source": [
-        "from math import ceil\n",
-        "from typing import Callable, Optional, List, Tuple, Union\n",
-        "\n",
         "import numpy as np\n",
         "\n",
         "import tensorflow as tf\n",
         "from tensorflow import keras\n",
         "from keras import Input, Sequential\n",
-        "from keras.layers import AveragePooling2D, Conv2D, Dense, Flatten, Layer"
+        "from keras.layers import AveragePooling2D, Conv2D, Dense, Flatten"
       ]
     },
     {


### PR DESCRIPTION
Since we moved the Subsampling layer into its own file, which has all of its
relevant imports there, we can drop the unused imports from the main notebook to
clean it up a bit.