### PR TITLE
Add basic implementation of AlexNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ results.
 Current implementations:
 
 * [LeNet](lenet) (1998)
+* [AlexNet](alexnet) (2012)
 
 ## Contributing
 

--- a/alexnet/Basic_AlexNet_in_Keras.ipynb
+++ b/alexnet/Basic_AlexNet_in_Keras.ipynb
@@ -1,0 +1,148 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Basic AlexNet in Keras",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "lVLBdJnv8SoF"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2022 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#      http://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import numpy as np\n",
+        "import tensorflow as tf\n",
+        "from tensorflow import keras\n",
+        "from keras import Input, Sequential\n",
+        "from keras.layers import Conv2D, Dense, Dropout, Flatten, MaxPool2D\n",
+        "from matplotlib import pyplot as plt"
+      ],
+      "metadata": {
+        "id": "3uryURdO8Uws"
+      },
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "This simple implementation does not split the data across 2 GPUs as described in the original paper for simplicity of implementation. It also does not include the custom response normalization layers (see the `TODO`s in the model below for where they should appear)."
+      ],
+      "metadata": {
+        "id": "pQIxFUn25W8J"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Define the model architecture.\n",
+        "model = Sequential([\n",
+        "    Input(shape=(227, 227, 3)),\n",
+        "    Conv2D(filters=96, kernel_size=(11, 11), strides=(4, 4), padding='valid', activation='relu', name='Conv1'),\n",
+        "    # TODO: add response normalization layer 1 here.\n",
+        "    MaxPool2D(pool_size=(3, 3), strides=(2, 2), padding='valid', name='MaxPool1'),\n",
+        "    Conv2D(filters=256, kernel_size=(5, 5), padding='same', activation='relu', name='Conv2'),\n",
+        "    # TODO: add response normalization layer 2 here.\n",
+        "    MaxPool2D(pool_size=(3, 3), strides=(2, 2), padding='valid', name='MaxPool2'),\n",
+        "    Conv2D(filters=384, kernel_size=(3, 3), padding='same', activation='relu', name='Conv3'),\n",
+        "    Conv2D(filters=384, kernel_size=(3, 3), padding='same', activation='relu', name='Conv4'),\n",
+        "    Conv2D(filters=256, kernel_size=(3, 3), padding='same', activation='relu', name='Conv5'),\n",
+        "    MaxPool2D(pool_size=(3, 3), strides=(2, 2), padding='valid', name='MaxPool3'),\n",
+        "    Flatten(name=\"Flatten\"),\n",
+        "    Dense(4096, activation='relu', name=\"Dense1\"),\n",
+        "    Dropout(0.5, name=\"Dropout1\"),\n",
+        "    Dense(4096, activation='relu', name=\"Dense2\"),\n",
+        "    Dropout(0.5, name=\"Dropout2\"),\n",
+        "    Dense(1000, activation='softmax', name=\"Output\"),\n",
+        "], name=\"AlexNet\")\n",
+        "\n",
+        "model.summary()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "JswAlt_l8qBC",
+        "outputId": "3c1fe12b-5753-45ec-bdd7-fcba9a48c0de"
+      },
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model: \"AlexNet\"\n",
+            "_________________________________________________________________\n",
+            " Layer (type)                Output Shape              Param #   \n",
+            "=================================================================\n",
+            " Conv1 (Conv2D)              (None, 55, 55, 96)        34944     \n",
+            "                                                                 \n",
+            " MaxPool1 (MaxPooling2D)     (None, 27, 27, 96)        0         \n",
+            "                                                                 \n",
+            " Conv2 (Conv2D)              (None, 27, 27, 256)       614656    \n",
+            "                                                                 \n",
+            " MaxPool2 (MaxPooling2D)     (None, 13, 13, 256)       0         \n",
+            "                                                                 \n",
+            " Conv3 (Conv2D)              (None, 13, 13, 384)       885120    \n",
+            "                                                                 \n",
+            " Conv4 (Conv2D)              (None, 13, 13, 384)       1327488   \n",
+            "                                                                 \n",
+            " Conv5 (Conv2D)              (None, 13, 13, 256)       884992    \n",
+            "                                                                 \n",
+            " MaxPool3 (MaxPooling2D)     (None, 6, 6, 256)         0         \n",
+            "                                                                 \n",
+            " Flatten (Flatten)           (None, 9216)              0         \n",
+            "                                                                 \n",
+            " Dense1 (Dense)              (None, 4096)              37752832  \n",
+            "                                                                 \n",
+            " Dropout1 (Dropout)          (None, 4096)              0         \n",
+            "                                                                 \n",
+            " Dense2 (Dense)              (None, 4096)              16781312  \n",
+            "                                                                 \n",
+            " Dropout2 (Dropout)          (None, 4096)              0         \n",
+            "                                                                 \n",
+            " Output (Dense)              (None, 1000)              4097000   \n",
+            "                                                                 \n",
+            "=================================================================\n",
+            "Total params: 62,378,344\n",
+            "Trainable params: 62,378,344\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/alexnet/README.md
+++ b/alexnet/README.md
@@ -1,0 +1,71 @@
+# AlexNet
+
+In this directory, we aim to implement the AlexNet architecture for a
+Convolutional Neural Network (CNN) used for image classification, to be tested
+with the ImageNet dataset.
+
+You can see an implementation in a [notebook](Basic_AlexNet_in_Keras.ipynb).
+
+> Note: we haven't yet trained or tested this network, as we don't yet have
+> access to the ImageNet dataset which requires registration & approval to be
+> able to download it.
+
+Our implementation is based on the following paper:
+
+* Alex Krizhevsky, Ilya Sutskever, and Geoffrey E. Hinton. 2012. ImageNet
+  Classification with Deep Convolutional Neural Networks. In Proceedings of the
+  25th International Conference on Neural Information Processing Systems -
+  Volume 1 (NeurIPS 2012). Curran Associates Inc., Red Hook, NY, USA, 1097–1105.
+
+The paper is available via:
+
+* [NeurIPS](https://papers.nips.cc/paper/2012/hash/c399862d3b9d6b76c8436e924a68c45b-Abstract.html)
+* [ACM Digital Library](https://dl.acm.org/doi/10.5555/2999134.2999257)
+* [CiteSeerX](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.299.205)
+
+See also:
+
+* [Slides on ImageNet](https://image-net.org/static_files/files/supervision.pdf)
+* [AlexNet on Wikipedia](https://en.wikipedia.org/wiki/AlexNet)
+
+# Differences from the paper
+
+This simple implementation does not split the data across 2 GPUs as described in
+the original paper for simplicity of implementation.
+
+Additionally, we haven't yet implemented the Local Response Normalization after
+the first two convolutional passes; the points where they should be added are
+marked with `TODO`s in the notebook.
+
+# Input size discrepancy
+
+Note that the original AlexNet paper refers to inputs as $224 \times 224$
+images; however, that does not work out to have $55 \times 55$ images as the
+output from the first convolutional layer. There's consensus that the only way
+to achieve that is to use input images of size $227 \times 227$, or images of
+size $224 \times 224$ with a 3-pixel zero-padding, which makes it work.
+
+Here are several references which agree on this analysis of input shape:
+
+1. [Classic Networks](https://youtu.be/dZVkygnKh1M?t=421) lecture by Andrew Ng
+   as part of the Deep Learning specialization
+
+   > If you read the paper, the paper refers to $224 \times 224 \times 3$
+   > images, but if you look at the numbers, the numbers only make sense if they
+   > are $227 \times 227 \times 3$.
+
+2. [Stanford CS231n](https://cs231n.github.io/convolutional-networks/)
+
+   > As a fun aside, if you read the actual paper it claims that the input
+   > images were 224x224, which is surely incorrect because (224 - 11)/4 + 1 is
+   > quite clearly not an integer. This has confused many people in the history
+   > of ConvNets and little is known about what happened. My own best guess is
+   > that Alex used zero-padding of 3 extra pixels that he does not mention in
+   > the paper.
+
+3. [Data Science SE](https://datascience.stackexchange.com/questions/29245/what-is-the-input-size-of-alex-net)
+
+   One answer also quotes Andrew Ng's lecture in (1) above. Another answer
+   demonstrates via calculation that the $224 \times 224$ input shape would
+   result in a non-integral output shape, and hence, must be an error, similarly
+   to the Stanford CS231n class notes in (2) above.


### PR DESCRIPTION
This does not split the data across 2 GPUs as described in the paper, and does
not yet have Local Response Normalization layer, but has the overall structure.

We can't train or test this model yet due to no access to ImageNet, and there
does not appear to be an easily accessible alternative labeled datasets with the
same number of categories to match this model structure, so we'll leave this
as-s for now.