### PR TITLE
Add VGG family of networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Current implementations:
 
 * [LeNet](lenet) (1998)
 * [AlexNet](alexnet) (2012)
+* [VGG](vgg) (2015)
 
 ## Contributing
 

--- a/vgg/Basic_VGG_in_Keras.ipynb
+++ b/vgg/Basic_VGG_in_Keras.ipynb
@@ -1,0 +1,650 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Basic VGG network in Keras",
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "Cd6PrIjsrx2d"
+      },
+      "outputs": [],
+      "source": [
+        "# Copyright 2022 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#      http://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from tensorflow import keras\n",
+        "from keras import Input, Sequential\n",
+        "from keras.layers import Activation, Conv2D, Dense, Flatten, MaxPool2D"
+      ],
+      "metadata": {
+        "id": "wxCnecJqr2LP"
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def Conv(filters: int, kernel_size: int, **kwargs) -> Conv2D:\n",
+        "    \"\"\"Shorthand for defining the Conv2D layers for VGG family of models.\n",
+        "    \n",
+        "    All VGG models have a stride of 1 and 'same' padding, so to avoid repeating\n",
+        "    these parameters (or skipping them, which leads to 'valid' padding), we use\n",
+        "    a convenience function here.\n",
+        "\n",
+        "    Additionally, all hidden layers in VGG are specified to use ReLU activation,\n",
+        "    so we include that here as well.\n",
+        "    \"\"\"\n",
+        "    return Conv2D(filters, kernel_size, strides=(1, 1), padding='same',\n",
+        "                  activation='relu', **kwargs)\n",
+        "\n",
+        "\n",
+        "def MaxPool(**kwargs) -> MaxPool2D:\n",
+        "    \"\"\"Shorthand for defining the MaxPool layers for VGG fmaily of models.\n",
+        "    \n",
+        "    All pooling layers in VGG are using kernel size of 2 with a stride of 2, so\n",
+        "    we define a shorthand here to ensure their uniformity.\n",
+        "    \"\"\"\n",
+        "    return MaxPool2D(pool_size=(2, 2), strides=(2, 2), **kwargs)"
+      ],
+      "metadata": {
+        "id": "k5eXee6L5SBs"
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Available model types.\n",
+        "MODEL_A = 'A'\n",
+        "MODEL_A_LRN = 'A-LRN'\n",
+        "MODEL_B = 'B'\n",
+        "MODEL_C = 'C'\n",
+        "MODEL_D = 'D'\n",
+        "MODEL_E = 'E'"
+      ],
+      "metadata": {
+        "id": "dv3LqkRc5Woo"
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def VGG(model: str) -> Sequential:\n",
+        "    \"\"\"Defines a specific VGG model, given one of the valid model types.\"\"\"\n",
+        "    assert model in (MODEL_A, MODEL_A_LRN, MODEL_B, MODEL_C, MODEL_D, MODEL_E)\n",
+        "\n",
+        "    vgg = Sequential([\n",
+        "        Input(shape=(224, 224, 3)),\n",
+        "    ], name=f'VGG-{model}')\n",
+        "\n",
+        "    # First block\n",
+        "    vgg.add(Conv2D(64, 3, 1, name=\"Conv2D_1_1\"))\n",
+        "    if model == MODEL_A:\n",
+        "        # No other layers are added here.\n",
+        "        pass\n",
+        "    elif model == MODEL_A_LRN:\n",
+        "        # TODO: add response normalization layer 1 here.\n",
+        "        pass\n",
+        "    else:\n",
+        "        vgg.add(Conv(64, 3, name=\"Conv2D_1_2\"))\n",
+        "    \n",
+        "    vgg.add(MaxPool(name=\"MaxPool_1\"))\n",
+        "\n",
+        "    # Second block\n",
+        "    vgg.add(Conv(128, 3, name=\"Conv2D_2_1\"))\n",
+        "    if model in (MODEL_B, MODEL_C, MODEL_D, MODEL_E):\n",
+        "        vgg.add(Conv(128, 3, name=\"Conv2D_2_2\"))\n",
+        "\n",
+        "    vgg.add(MaxPool(name=\"MaxPool_2\"))\n",
+        "\n",
+        "    # Third block\n",
+        "    vgg.add(Conv(256, 3, name=\"Conv2D_3_1\"))\n",
+        "    vgg.add(Conv(256, 3, name=\"Conv2D_3_2\"))\n",
+        "\n",
+        "    if model == MODEL_C:\n",
+        "        vgg.add(Conv(256, 1, name=\"Conv2D_3_3\"))\n",
+        "    elif model in (MODEL_D, MODEL_E):\n",
+        "        vgg.add(Conv(256, 3, name=\"Conv2D_3_3\"))\n",
+        "\n",
+        "    # Model E gets an extra layer.\n",
+        "    if model == MODEL_E:\n",
+        "        vgg.add(Conv(256, 3, name=\"Conv2D_3_4\"))\n",
+        "\n",
+        "    vgg.add(MaxPool(name=\"MaxPool_3\"))\n",
+        "\n",
+        "    # Fourth block\n",
+        "    vgg.add(Conv(512, 3, name=\"Conv2D_4_1\"))\n",
+        "    vgg.add(Conv(512, 3, name=\"Conv2D_4_2\"))\n",
+        "\n",
+        "    if model == MODEL_C:\n",
+        "        vgg.add(Conv(512, 1, name=\"Conv2D_4_3\"))\n",
+        "    elif model in (MODEL_D, MODEL_E):\n",
+        "        vgg.add(Conv(512, 3, name=\"Conv2D_4_4\"))\n",
+        "\n",
+        "    # Model E gets an extra layer.\n",
+        "    if model == MODEL_E:\n",
+        "        vgg.add(Conv(512, 3, name=\"Conv2D_4_5\"))\n",
+        "\n",
+        "    vgg.add(MaxPool(name=\"MaxPool_4\"))\n",
+        "\n",
+        "    # Fifth block\n",
+        "    vgg.add(Conv(512, 3, name=\"Conv2D_5_1\"))\n",
+        "    vgg.add(Conv(512, 3, name=\"Conv2D_5_2\"))\n",
+        "    if model == MODEL_C:\n",
+        "        vgg.add(Conv(512, 1, name=\"Conv2D_5_3\"))\n",
+        "    elif model in (MODEL_D, MODEL_E):\n",
+        "        vgg.add(Conv(512, 3, name=\"Conv2D_5_3\"))\n",
+        "\n",
+        "    # Model E gets an extra layer.\n",
+        "    if model == MODEL_E:\n",
+        "        vgg.add(Conv(512, 3, name=\"Conv2D_5_4\"))\n",
+        "\n",
+        "    vgg.add(MaxPool(name=\"MaxPool_5\"))\n",
+        "\n",
+        "    vgg.add(Flatten())\n",
+        "    vgg.add(Dense(4096, name=\"FC_1\", activation='relu'))\n",
+        "    vgg.add(Dense(4096, name=\"FC_2\", activation='relu'))\n",
+        "    vgg.add(Dense(1000, name=\"FC_3\", activation='relu'))\n",
+        "    vgg.add(Activation(keras.activations.softmax, name=\"Softmax\"))\n",
+        "\n",
+        "    return vgg"
+      ],
+      "metadata": {
+        "id": "0feiTuI5r4G0"
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "VGG_A = VGG(MODEL_A)\n",
+        "VGG_A_LRN = VGG(MODEL_A_LRN)\n",
+        "VGG_B = VGG(MODEL_B)\n",
+        "VGG_C = VGG(MODEL_C)\n",
+        "VGG_D = VGG(MODEL_D)\n",
+        "VGG_E = VGG(MODEL_E)"
+      ],
+      "metadata": {
+        "id": "5T3pkvY_151d"
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "VGG_A.summary()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "LM2znmml0AZX",
+        "outputId": "5d6b58e8-de07-4309-984c-cf4aa16622ff"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model: \"VGG-A\"\n",
+            "_________________________________________________________________\n",
+            " Layer (type)                Output Shape              Param #   \n",
+            "=================================================================\n",
+            " Conv2D_1_1 (Conv2D)         (None, 222, 222, 64)      1792      \n",
+            "                                                                 \n",
+            " MaxPool_1 (MaxPooling2D)    (None, 111, 111, 64)      0         \n",
+            "                                                                 \n",
+            " Conv2D_2_1 (Conv2D)         (None, 111, 111, 128)     73856     \n",
+            "                                                                 \n",
+            " MaxPool_2 (MaxPooling2D)    (None, 55, 55, 128)       0         \n",
+            "                                                                 \n",
+            " Conv2D_3_1 (Conv2D)         (None, 55, 55, 256)       295168    \n",
+            "                                                                 \n",
+            " Conv2D_3_2 (Conv2D)         (None, 55, 55, 256)       590080    \n",
+            "                                                                 \n",
+            " MaxPool_3 (MaxPooling2D)    (None, 27, 27, 256)       0         \n",
+            "                                                                 \n",
+            " Conv2D_4_1 (Conv2D)         (None, 27, 27, 512)       1180160   \n",
+            "                                                                 \n",
+            " Conv2D_4_2 (Conv2D)         (None, 27, 27, 512)       2359808   \n",
+            "                                                                 \n",
+            " MaxPool_4 (MaxPooling2D)    (None, 13, 13, 512)       0         \n",
+            "                                                                 \n",
+            " Conv2D_5_1 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_5_2 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " MaxPool_5 (MaxPooling2D)    (None, 6, 6, 512)         0         \n",
+            "                                                                 \n",
+            " flatten_12 (Flatten)        (None, 18432)             0         \n",
+            "                                                                 \n",
+            " FC_1 (Dense)                (None, 4096)              75501568  \n",
+            "                                                                 \n",
+            " FC_2 (Dense)                (None, 4096)              16781312  \n",
+            "                                                                 \n",
+            " FC_3 (Dense)                (None, 1000)              4097000   \n",
+            "                                                                 \n",
+            " Softmax (Activation)        (None, 1000)              0         \n",
+            "                                                                 \n",
+            "=================================================================\n",
+            "Total params: 105,600,360\n",
+            "Trainable params: 105,600,360\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "VGG_A_LRN.summary()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Ka4dmIKK0D3z",
+        "outputId": "d704762d-4eed-45fa-9080-0d03331906c1"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model: \"VGG-A-LRN\"\n",
+            "_________________________________________________________________\n",
+            " Layer (type)                Output Shape              Param #   \n",
+            "=================================================================\n",
+            " Conv2D_1_1 (Conv2D)         (None, 222, 222, 64)      1792      \n",
+            "                                                                 \n",
+            " MaxPool_1 (MaxPooling2D)    (None, 111, 111, 64)      0         \n",
+            "                                                                 \n",
+            " Conv2D_2_1 (Conv2D)         (None, 111, 111, 128)     73856     \n",
+            "                                                                 \n",
+            " MaxPool_2 (MaxPooling2D)    (None, 55, 55, 128)       0         \n",
+            "                                                                 \n",
+            " Conv2D_3_1 (Conv2D)         (None, 55, 55, 256)       295168    \n",
+            "                                                                 \n",
+            " Conv2D_3_2 (Conv2D)         (None, 55, 55, 256)       590080    \n",
+            "                                                                 \n",
+            " MaxPool_3 (MaxPooling2D)    (None, 27, 27, 256)       0         \n",
+            "                                                                 \n",
+            " Conv2D_4_1 (Conv2D)         (None, 27, 27, 512)       1180160   \n",
+            "                                                                 \n",
+            " Conv2D_4_2 (Conv2D)         (None, 27, 27, 512)       2359808   \n",
+            "                                                                 \n",
+            " MaxPool_4 (MaxPooling2D)    (None, 13, 13, 512)       0         \n",
+            "                                                                 \n",
+            " Conv2D_5_1 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_5_2 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " MaxPool_5 (MaxPooling2D)    (None, 6, 6, 512)         0         \n",
+            "                                                                 \n",
+            " flatten_13 (Flatten)        (None, 18432)             0         \n",
+            "                                                                 \n",
+            " FC_1 (Dense)                (None, 4096)              75501568  \n",
+            "                                                                 \n",
+            " FC_2 (Dense)                (None, 4096)              16781312  \n",
+            "                                                                 \n",
+            " FC_3 (Dense)                (None, 1000)              4097000   \n",
+            "                                                                 \n",
+            " Softmax (Activation)        (None, 1000)              0         \n",
+            "                                                                 \n",
+            "=================================================================\n",
+            "Total params: 105,600,360\n",
+            "Trainable params: 105,600,360\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "VGG_B.summary()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "YkDUZ1Yr0EYe",
+        "outputId": "3ab0cc76-4c98-4be8-8130-1ae807ae68a8"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model: \"VGG-B\"\n",
+            "_________________________________________________________________\n",
+            " Layer (type)                Output Shape              Param #   \n",
+            "=================================================================\n",
+            " Conv2D_1_1 (Conv2D)         (None, 222, 222, 64)      1792      \n",
+            "                                                                 \n",
+            " Conv2D_1_2 (Conv2D)         (None, 222, 222, 64)      36928     \n",
+            "                                                                 \n",
+            " MaxPool_1 (MaxPooling2D)    (None, 111, 111, 64)      0         \n",
+            "                                                                 \n",
+            " Conv2D_2_1 (Conv2D)         (None, 111, 111, 128)     73856     \n",
+            "                                                                 \n",
+            " Conv2D_2_2 (Conv2D)         (None, 111, 111, 128)     147584    \n",
+            "                                                                 \n",
+            " MaxPool_2 (MaxPooling2D)    (None, 55, 55, 128)       0         \n",
+            "                                                                 \n",
+            " Conv2D_3_1 (Conv2D)         (None, 55, 55, 256)       295168    \n",
+            "                                                                 \n",
+            " Conv2D_3_2 (Conv2D)         (None, 55, 55, 256)       590080    \n",
+            "                                                                 \n",
+            " MaxPool_3 (MaxPooling2D)    (None, 27, 27, 256)       0         \n",
+            "                                                                 \n",
+            " Conv2D_4_1 (Conv2D)         (None, 27, 27, 512)       1180160   \n",
+            "                                                                 \n",
+            " Conv2D_4_2 (Conv2D)         (None, 27, 27, 512)       2359808   \n",
+            "                                                                 \n",
+            " MaxPool_4 (MaxPooling2D)    (None, 13, 13, 512)       0         \n",
+            "                                                                 \n",
+            " Conv2D_5_1 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_5_2 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " MaxPool_5 (MaxPooling2D)    (None, 6, 6, 512)         0         \n",
+            "                                                                 \n",
+            " flatten_14 (Flatten)        (None, 18432)             0         \n",
+            "                                                                 \n",
+            " FC_1 (Dense)                (None, 4096)              75501568  \n",
+            "                                                                 \n",
+            " FC_2 (Dense)                (None, 4096)              16781312  \n",
+            "                                                                 \n",
+            " FC_3 (Dense)                (None, 1000)              4097000   \n",
+            "                                                                 \n",
+            " Softmax (Activation)        (None, 1000)              0         \n",
+            "                                                                 \n",
+            "=================================================================\n",
+            "Total params: 105,784,872\n",
+            "Trainable params: 105,784,872\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "VGG_C.summary()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "evyOFgiD0GVI",
+        "outputId": "41107897-9384-4920-ba04-26061295a61a"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model: \"VGG-C\"\n",
+            "_________________________________________________________________\n",
+            " Layer (type)                Output Shape              Param #   \n",
+            "=================================================================\n",
+            " Conv2D_1_1 (Conv2D)         (None, 222, 222, 64)      1792      \n",
+            "                                                                 \n",
+            " Conv2D_1_2 (Conv2D)         (None, 222, 222, 64)      36928     \n",
+            "                                                                 \n",
+            " MaxPool_1 (MaxPooling2D)    (None, 111, 111, 64)      0         \n",
+            "                                                                 \n",
+            " Conv2D_2_1 (Conv2D)         (None, 111, 111, 128)     73856     \n",
+            "                                                                 \n",
+            " Conv2D_2_2 (Conv2D)         (None, 111, 111, 128)     147584    \n",
+            "                                                                 \n",
+            " MaxPool_2 (MaxPooling2D)    (None, 55, 55, 128)       0         \n",
+            "                                                                 \n",
+            " Conv2D_3_1 (Conv2D)         (None, 55, 55, 256)       295168    \n",
+            "                                                                 \n",
+            " Conv2D_3_2 (Conv2D)         (None, 55, 55, 256)       590080    \n",
+            "                                                                 \n",
+            " Conv2D_3_3 (Conv2D)         (None, 55, 55, 256)       65792     \n",
+            "                                                                 \n",
+            " MaxPool_3 (MaxPooling2D)    (None, 27, 27, 256)       0         \n",
+            "                                                                 \n",
+            " Conv2D_4_1 (Conv2D)         (None, 27, 27, 512)       1180160   \n",
+            "                                                                 \n",
+            " Conv2D_4_2 (Conv2D)         (None, 27, 27, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_4_3 (Conv2D)         (None, 27, 27, 512)       262656    \n",
+            "                                                                 \n",
+            " MaxPool_4 (MaxPooling2D)    (None, 13, 13, 512)       0         \n",
+            "                                                                 \n",
+            " Conv2D_5_1 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_5_2 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_5_3 (Conv2D)         (None, 13, 13, 512)       262656    \n",
+            "                                                                 \n",
+            " MaxPool_5 (MaxPooling2D)    (None, 6, 6, 512)         0         \n",
+            "                                                                 \n",
+            " flatten_15 (Flatten)        (None, 18432)             0         \n",
+            "                                                                 \n",
+            " FC_1 (Dense)                (None, 4096)              75501568  \n",
+            "                                                                 \n",
+            " FC_2 (Dense)                (None, 4096)              16781312  \n",
+            "                                                                 \n",
+            " FC_3 (Dense)                (None, 1000)              4097000   \n",
+            "                                                                 \n",
+            " Softmax (Activation)        (None, 1000)              0         \n",
+            "                                                                 \n",
+            "=================================================================\n",
+            "Total params: 106,375,976\n",
+            "Trainable params: 106,375,976\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "VGG_D.summary()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "RkgGL2lZ0GK4",
+        "outputId": "d7028b36-b5d0-44a5-c5b5-d3e741609820"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model: \"VGG-D\"\n",
+            "_________________________________________________________________\n",
+            " Layer (type)                Output Shape              Param #   \n",
+            "=================================================================\n",
+            " Conv2D_1_1 (Conv2D)         (None, 222, 222, 64)      1792      \n",
+            "                                                                 \n",
+            " Conv2D_1_2 (Conv2D)         (None, 222, 222, 64)      36928     \n",
+            "                                                                 \n",
+            " MaxPool_1 (MaxPooling2D)    (None, 111, 111, 64)      0         \n",
+            "                                                                 \n",
+            " Conv2D_2_1 (Conv2D)         (None, 111, 111, 128)     73856     \n",
+            "                                                                 \n",
+            " Conv2D_2_2 (Conv2D)         (None, 111, 111, 128)     147584    \n",
+            "                                                                 \n",
+            " MaxPool_2 (MaxPooling2D)    (None, 55, 55, 128)       0         \n",
+            "                                                                 \n",
+            " Conv2D_3_1 (Conv2D)         (None, 55, 55, 256)       295168    \n",
+            "                                                                 \n",
+            " Conv2D_3_2 (Conv2D)         (None, 55, 55, 256)       590080    \n",
+            "                                                                 \n",
+            " Conv2D_3_3 (Conv2D)         (None, 55, 55, 256)       590080    \n",
+            "                                                                 \n",
+            " MaxPool_3 (MaxPooling2D)    (None, 27, 27, 256)       0         \n",
+            "                                                                 \n",
+            " Conv2D_4_1 (Conv2D)         (None, 27, 27, 512)       1180160   \n",
+            "                                                                 \n",
+            " Conv2D_4_2 (Conv2D)         (None, 27, 27, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_4_4 (Conv2D)         (None, 27, 27, 512)       2359808   \n",
+            "                                                                 \n",
+            " MaxPool_4 (MaxPooling2D)    (None, 13, 13, 512)       0         \n",
+            "                                                                 \n",
+            " Conv2D_5_1 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_5_2 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_5_3 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " MaxPool_5 (MaxPooling2D)    (None, 6, 6, 512)         0         \n",
+            "                                                                 \n",
+            " flatten_16 (Flatten)        (None, 18432)             0         \n",
+            "                                                                 \n",
+            " FC_1 (Dense)                (None, 4096)              75501568  \n",
+            "                                                                 \n",
+            " FC_2 (Dense)                (None, 4096)              16781312  \n",
+            "                                                                 \n",
+            " FC_3 (Dense)                (None, 1000)              4097000   \n",
+            "                                                                 \n",
+            " Softmax (Activation)        (None, 1000)              0         \n",
+            "                                                                 \n",
+            "=================================================================\n",
+            "Total params: 111,094,568\n",
+            "Trainable params: 111,094,568\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "VGG_E.summary()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "o2BKw_OM0Fvh",
+        "outputId": "206e2a85-7ac3-451b-c67e-c2a2356f529d"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model: \"VGG-E\"\n",
+            "_________________________________________________________________\n",
+            " Layer (type)                Output Shape              Param #   \n",
+            "=================================================================\n",
+            " Conv2D_1_1 (Conv2D)         (None, 222, 222, 64)      1792      \n",
+            "                                                                 \n",
+            " Conv2D_1_2 (Conv2D)         (None, 222, 222, 64)      36928     \n",
+            "                                                                 \n",
+            " MaxPool_1 (MaxPooling2D)    (None, 111, 111, 64)      0         \n",
+            "                                                                 \n",
+            " Conv2D_2_1 (Conv2D)         (None, 111, 111, 128)     73856     \n",
+            "                                                                 \n",
+            " Conv2D_2_2 (Conv2D)         (None, 111, 111, 128)     147584    \n",
+            "                                                                 \n",
+            " MaxPool_2 (MaxPooling2D)    (None, 55, 55, 128)       0         \n",
+            "                                                                 \n",
+            " Conv2D_3_1 (Conv2D)         (None, 55, 55, 256)       295168    \n",
+            "                                                                 \n",
+            " Conv2D_3_2 (Conv2D)         (None, 55, 55, 256)       590080    \n",
+            "                                                                 \n",
+            " Conv2D_3_3 (Conv2D)         (None, 55, 55, 256)       590080    \n",
+            "                                                                 \n",
+            " Conv2D_3_4 (Conv2D)         (None, 55, 55, 256)       590080    \n",
+            "                                                                 \n",
+            " MaxPool_3 (MaxPooling2D)    (None, 27, 27, 256)       0         \n",
+            "                                                                 \n",
+            " Conv2D_4_1 (Conv2D)         (None, 27, 27, 512)       1180160   \n",
+            "                                                                 \n",
+            " Conv2D_4_2 (Conv2D)         (None, 27, 27, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_4_4 (Conv2D)         (None, 27, 27, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_4_5 (Conv2D)         (None, 27, 27, 512)       2359808   \n",
+            "                                                                 \n",
+            " MaxPool_4 (MaxPooling2D)    (None, 13, 13, 512)       0         \n",
+            "                                                                 \n",
+            " Conv2D_5_1 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_5_2 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_5_3 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " Conv2D_5_4 (Conv2D)         (None, 13, 13, 512)       2359808   \n",
+            "                                                                 \n",
+            " MaxPool_5 (MaxPooling2D)    (None, 6, 6, 512)         0         \n",
+            "                                                                 \n",
+            " flatten_17 (Flatten)        (None, 18432)             0         \n",
+            "                                                                 \n",
+            " FC_1 (Dense)                (None, 4096)              75501568  \n",
+            "                                                                 \n",
+            " FC_2 (Dense)                (None, 4096)              16781312  \n",
+            "                                                                 \n",
+            " FC_3 (Dense)                (None, 1000)              4097000   \n",
+            "                                                                 \n",
+            " Softmax (Activation)        (None, 1000)              0         \n",
+            "                                                                 \n",
+            "=================================================================\n",
+            "Total params: 116,404,264\n",
+            "Trainable params: 116,404,264\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/vgg/README.md
+++ b/vgg/README.md
@@ -1,0 +1,40 @@
+# VGG
+
+In this directory, we aim to implement the VGG family of convolutional neural
+network (CNN) models for image classification, including the well-known VGG-16
+and VGG-19 models, to be tested with the ImageNet dataset.
+
+You can see our implementation in a [notebook](Basic_VGG_in_Keras.ipynb).
+
+Implementation notes:
+
+1. We haven't yet trained or tested this network, as we don't yet have access to
+   the ImageNet dataset which requires registration & approval to be able to
+   download it.
+2. We haven't yet implemented the Local Response Normalization layer (borrowed
+   from AlexNet), but the authors of the VGG paper noted that it did not provide
+   an improvement over not using it.
+
+Our implementation is based on the following paper:
+
+* Karen Simonyan and Andrew Zisserman. "Very deep convolutional networks for
+  large-scale image recognition." arXiv preprint arXiv:1409.1556 (2014).
+
+> Note: this paper was also published in ICLR 2015.
+
+This paper is available via:
+
+* [Visual Geometry Group at Oxford][paper-vgg]
+* [arXiv][arxiv-vgg]
+* [CiteSeerX][citeseerx-vgg]
+
+See also:
+
+* [VGG report from the authors][model-info] - links to download models
+* [Papers with Code][pwc-vgg]
+
+[paper-vgg]: https://www.robots.ox.ac.uk/~vgg/publications/2015/Simonyan15/
+[arxiv-vgg]: https://arxiv.org/abs/1409.1556
+[citeseerx-vgg]: https://citeseerx.ist.psu.edu/viewdoc/summary;?doi=10.1.1.740.6937
+[model-info]: https://www.robots.ox.ac.uk/~vgg/research/very_deep/
+[pwc-vgg]: https://paperswithcode.com/method/vgg


### PR DESCRIPTION
The notebook enables creating all the network variants defined in the paper, but
we can't train or test any of these networks until we get access to the ImageNet
dataset.