### PR TITLE
Add tables for AlexNet and VGG model impls

### DIFF
--- a/alexnet/README.md
+++ b/alexnet/README.md
@@ -4,11 +4,23 @@ In this directory, we aim to implement the AlexNet architecture for a
 Convolutional Neural Network (CNN) used for image classification, to be tested
 with the ImageNet dataset.
 
-You can see an implementation in a [notebook](Basic_AlexNet_in_Keras.ipynb).
+Available implementations:
 
-> Note: we haven't yet trained or tested this network, as we don't yet have
-> access to the ImageNet dataset which requires registration & approval to be
-> able to download it.
+|      | Description    | Library | GitHub<br/>(readonly) | Colab | Binder |
+|:----:| -------------- |:-------:|:---------------------:|:-----:|:------:|
+|  v1  | Basic impl     |  Keras  | [![View on GitHub][github-badge]][github-basic] | [![Open In Colab][colab-badge]][colab-basic] | [![Open in Binder][binder-badge]][binder-basic] |
+
+Implementation notes for v1:
+
+1. We haven't yet trained or tested this network, as we don't yet have access to
+   the ImageNet dataset which requires registration & approval to be able to
+   download it.
+2. We haven't yet implemented the Local Response Normalization layer after the
+   first two convolutional passes; the points where they should be added are
+   marked with `TODO`s in the notebook.
+3. This simple implementation does not split the data across 2 GPUs as described
+   in the paper for simplicity, and because we no longer have such resource
+   constraints in today's GPUs.
 
 Our implementation is based on the following paper:
 
@@ -19,23 +31,14 @@ Our implementation is based on the following paper:
 
 The paper is available via:
 
-* [NeurIPS](https://papers.nips.cc/paper/2012/hash/c399862d3b9d6b76c8436e924a68c45b-Abstract.html)
-* [ACM Digital Library](https://dl.acm.org/doi/10.5555/2999134.2999257)
-* [CiteSeerX](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.299.205)
+* [NeurIPS][neurips-alexnet]
+* [ACM Digital Library][acm-alexnet]
+* [CiteSeerX][citeseer-alexnet]
 
 See also:
 
-* [Slides on ImageNet](https://image-net.org/static_files/files/supervision.pdf)
-* [AlexNet on Wikipedia](https://en.wikipedia.org/wiki/AlexNet)
-
-# Differences from the paper
-
-This simple implementation does not split the data across 2 GPUs as described in
-the original paper for simplicity of implementation.
-
-Additionally, we haven't yet implemented the Local Response Normalization after
-the first two convolutional passes; the points where they should be added are
-marked with `TODO`s in the notebook.
+* [Slides on ImageNet][imagenet-slides]
+* [AlexNet on Wikipedia][alexnet-wiki]
 
 # Input size discrepancy
 
@@ -47,14 +50,14 @@ size $224 \times 224$ with a 3-pixel zero-padding, which makes it work.
 
 Here are several references which agree on this analysis of input shape:
 
-1. [Classic Networks](https://youtu.be/dZVkygnKh1M?t=421) lecture by Andrew Ng
-   as part of the Deep Learning specialization
+1. [Classic Networks][classic-networks] lecture by Andrew Ng as part of the Deep
+   Learning specialization
 
    > If you read the paper, the paper refers to $224 \times 224 \times 3$
    > images, but if you look at the numbers, the numbers only make sense if they
    > are $227 \times 227 \times 3$.
 
-2. [Stanford CS231n](https://cs231n.github.io/convolutional-networks/)
+2. [Stanford CS231n][stanford-cs231n]
 
    > As a fun aside, if you read the actual paper it claims that the input
    > images were 224x224, which is surely incorrect because (224 - 11)/4 + 1 is
@@ -63,9 +66,28 @@ Here are several references which agree on this analysis of input shape:
    > that Alex used zero-padding of 3 extra pixels that he does not mention in
    > the paper.
 
-3. [Data Science SE](https://datascience.stackexchange.com/questions/29245/what-is-the-input-size-of-alex-net)
+3. [Data Science SE][datascience-se]
 
    One answer also quotes Andrew Ng's lecture in (1) above. Another answer
    demonstrates via calculation that the $224 \times 224$ input shape would
    result in a non-integral output shape, and hence, must be an error, similarly
    to the Stanford CS231n class notes in (2) above.
+
+[github-badge]: https://img.shields.io/badge/View-GitHub-blue
+[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg
+[binder-badge]: https://static.mybinder.org/badge_logo.svg
+
+[github-basic]: Basic_AlexNet_in_Keras.ipynb
+[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/alexnet/Basic_AlexNet_in_Keras.ipynb
+[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=alexnet/Basic_AlexNet_in_Keras.ipynb
+
+[neurips-alexnet]: https://papers.nips.cc/paper/2012/hash/c399862d3b9d6b76c8436e924a68c45b-Abstract.html
+[acm-alexnet]: https://dl.acm.org/doi/10.5555/2999134.2999257
+[citeseer-alexnet]: http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.299.205
+
+[imagenet-slides]: https://image-net.org/static_files/files/supervision.pdf
+[alexnet-wiki]: https://en.wikipedia.org/wiki/AlexNet
+
+[classic-networks]: https://youtu.be/dZVkygnKh1M?t=421
+[stanford-cs231n]: https://cs231n.github.io/convolutional-networks/
+[datascience-se]: https://datascience.stackexchange.com/questions/29245/what-is-the-input-size-of-alex-net

--- a/vgg/README.md
+++ b/vgg/README.md
@@ -4,9 +4,13 @@ In this directory, we aim to implement the VGG family of convolutional neural
 network (CNN) models for image classification, including the well-known VGG-16
 and VGG-19 models, to be tested with the ImageNet dataset.
 
-You can see our implementation in a [notebook](Basic_VGG_in_Keras.ipynb).
+Available implementations:
 
-Implementation notes:
+|      | Description    | Library | GitHub<br/>(readonly) | Colab | Binder |
+|:----:| -------------- |:-------:|:---------------------:|:-----:|:------:|
+|  v1  | Basic impl     |  Keras  | [![View on GitHub][github-badge]][github-basic] | [![Open In Colab][colab-badge]][colab-basic] | [![Open in Binder][binder-badge]][binder-basic] |
+
+Implementation notes for v1:
 
 1. We haven't yet trained or tested this network, as we don't yet have access to
    the ImageNet dataset which requires registration & approval to be able to
@@ -32,6 +36,14 @@ See also:
 
 * [VGG report from the authors][model-info] - links to download models
 * [Papers with Code][pwc-vgg]
+
+[github-badge]: https://img.shields.io/badge/View-GitHub-blue
+[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg
+[binder-badge]: https://static.mybinder.org/badge_logo.svg
+
+[github-basic]: Basic_VGG_in_Keras.ipynb
+[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/vgg/Basic_VGG_in_Keras.ipynb
+[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=vgg/Basic_VGG_in_Keras.ipynb
 
 [paper-vgg]: https://www.robots.ox.ac.uk/~vgg/publications/2015/Simonyan15/
 [arxiv-vgg]: https://arxiv.org/abs/1409.1556


### PR DESCRIPTION
Follow the pattern for LeNet to create an expandable table of various
implementation versions, and also add links to Colab and Binder for exploration
of the implementations.

For AlexNet, move all inline links to the bottom for readability and
consistency.