### PR TITLE
Remove extra `import tensorflow as tf` statement

### DIFF
--- a/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+++ b/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
@@ -33,7 +33,6 @@
       "source": [
         "import numpy as np\n",
         "\n",
-        "import tensorflow as tf\n",
         "from tensorflow import keras\n",
         "from keras import Input, Sequential\n",
         "from keras.layers import AveragePooling2D, Conv2D, Dense, Flatten"
@@ -61,7 +60,7 @@
       "outputs": [],
       "source": [
         "# Load the MNIST dataset.\n",
-        "(x_train_raw, y_train_raw), (x_test_raw, y_test_raw) = tf.keras.datasets.mnist.load_data()"
+        "(x_train_raw, y_train_raw), (x_test_raw, y_test_raw) = keras.datasets.mnist.load_data()"
       ]
     },
     {


### PR DESCRIPTION
We don't actually need it, because the only place it's used is for referencing
`tf.keras.datasets`, but we already have `from tensorflow import keras`, so we
can access it simply as `keras.datasets` using the existing import.