### PR TITLE
LeNet v3: fixed scaling and learning rate decay

### DIFF
--- a/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+++ b/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
@@ -1,0 +1,432 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "# Copyright 2022 Google LLC\n",
+        "#\n",
+        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "#      http://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "metadata": {
+        "id": "-52CicmjShjz"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "OfRXb7AXBNoB"
+      },
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "\n",
+        "from tensorflow import keras\n",
+        "from keras import Input, Sequential\n",
+        "from keras.layers import AveragePooling2D, Conv2D, Dense, Flatten"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Download and import custom Subsampling layer.\n",
+        "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
+        "from subsampling import Subsampling"
+      ],
+      "metadata": {
+        "id": "R5nia9YHVMKc"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "rEBeAvrWBQCU",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "fa48284b-24ac-42cc-bc6e-d7a30abd278a"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz\n",
+            "11493376/11490434 [==============================] - 0s 0us/step\n",
+            "11501568/11490434 [==============================] - 0s 0us/step\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Load the MNIST dataset.\n",
+        "(x_train_raw, y_train_raw), (x_test_raw, y_test_raw) = keras.datasets.mnist.load_data()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Examine the dataset shape.\n",
+        "print(\"Raw data:\")\n",
+        "print(f\"Train x: {x_train_raw.shape}\")\n",
+        "print(f\"      y: {y_train_raw.shape}\")\n",
+        "print(f\"Test  x: {x_test_raw.shape}\")\n",
+        "print(f\"      y: {y_test_raw.shape}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "L9SC3sIaDv_i",
+        "outputId": "8f68e841-cb01-4879-fd2d-182efb3dc49d"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Raw data:\n",
+            "Train x: (60000, 28, 28)\n",
+            "      y: (60000,)\n",
+            "Test  x: (10000, 28, 28)\n",
+            "      y: (10000,)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "num_classes = 10\n",
+        "\n",
+        "# Expand the dimensions of our inputs to ensure their shape is (28, 28, 1),\n",
+        "# rather than (28, 28) which is what they are by default.\n",
+        "x_train = np.expand_dims(x_train_raw, -1)\n",
+        "x_test = np.expand_dims(x_test_raw, -1)\n",
+        "\n",
+        "# Scale train and test inputs by converting them from range of [0, 255] to\n",
+        "# [-0.1, 1.175]. From the LeNet paper, pg. 7:\n",
+        "#\n",
+        "#     \"The values of the input pixels are normalized so that the background level\n",
+        "#      white\b corresponds to a value of -0.1 and the foreground black\b corresponds\n",
+        "#      to 1.175. This makes the mean input roughly 0 and the variance roughly 1\n",
+        "#      which accelerates learning.\"\n",
+        "lower_bound = -0.1\n",
+        "upper_bound = 1.175\n",
+        "x_train = x_train_raw.astype('float32') / 255.0 * (upper_bound - lower_bound) - abs(lower_bound)\n",
+        "x_test = x_test_raw.astype('float32') / 255.0 * (upper_bound - lower_bound) - abs(lower_bound)\n",
+        "\n",
+        "# Convert the output to categorical one-hot encoding to match the output of our\n",
+        "# network.\n",
+        "y_train = keras.utils.to_categorical(y_train_raw, num_classes)\n",
+        "y_test = keras.utils.to_categorical(y_test_raw, num_classes)\n",
+        "\n",
+        "print(\"\\nProcessed data:\")\n",
+        "print(f\"Train x: {x_train.shape}\")\n",
+        "print(f\"      y: {y_train.shape}\")\n",
+        "print(f\"Test  x: {x_test.shape}\")\n",
+        "print(f\"      y: {y_test.shape}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "mhnNc_LSAoWh",
+        "outputId": "847ad556-dc9a-4a91-a6fb-baa0eee6e69b"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "Processed data:\n",
+            "Train x: (60000, 28, 28)\n",
+            "      y: (60000, 10)\n",
+            "Test  x: (10000, 28, 28)\n",
+            "      y: (10000, 10)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6oCDY6OEDrOp",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "63593869-1c79-4752-f2d1-5f561343b172"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Y values before preprocessing:\n",
+            "[5 0 4 1]\n",
+            "\n",
+            "Y values after preprocessing:\n",
+            "[[0. 0. 0. 0. 0. 1. 0. 0. 0. 0.]\n",
+            " [1. 0. 0. 0. 0. 0. 0. 0. 0. 0.]\n",
+            " [0. 0. 0. 0. 1. 0. 0. 0. 0. 0.]\n",
+            " [0. 1. 0. 0. 0. 0. 0. 0. 0. 0.]]\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Examine the format of the Y values before and after preprocessing.\n",
+        "print('Y values before preprocessing:')\n",
+        "print(y_train_raw[0:4])\n",
+        "\n",
+        "print('\\nY values after preprocessing:')\n",
+        "print(y_train[0:4])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def lenet_activation(a: float) -> float:\n",
+        "    A = 1.7159\n",
+        "    S = 2. / 3\n",
+        "    return A * keras.activations.tanh(S * a)"
+      ],
+      "metadata": {
+        "id": "rSmV5tE911bM"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "eptAFMyWBD8L",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "5f2cc55f-38a2-4766-a7f3-3bf874e680ab"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model: \"LeNet-5\"\n",
+            "_________________________________________________________________\n",
+            " Layer (type)                Output Shape              Param #   \n",
+            "=================================================================\n",
+            " C1 (Conv2D)                 (None, 28, 28, 6)         156       \n",
+            "                                                                 \n",
+            " S2 (Subsampling)            (None, 14, 14, 6)         12        \n",
+            "                                                                 \n",
+            " C3 (Conv2D)                 (None, 10, 10, 16)        2416      \n",
+            "                                                                 \n",
+            " S4 (Subsampling)            (None, 5, 5, 16)          32        \n",
+            "                                                                 \n",
+            " flatten (Flatten)           (None, 400)               0         \n",
+            "                                                                 \n",
+            " C5 (Dense)                  (None, 120)               48120     \n",
+            "                                                                 \n",
+            " F6 (Dense)                  (None, 84)                10164     \n",
+            "                                                                 \n",
+            " Output (Dense)              (None, 10)                850       \n",
+            "                                                                 \n",
+            "=================================================================\n",
+            "Total params: 61,750\n",
+            "Trainable params: 61,750\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n"
+          ]
+        }
+      ],
+      "source": [
+        "model = Sequential([\n",
+        "    Input(shape=(28, 28, 1)),\n",
+        "    Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=lenet_activation, name=\"C1\"),\n",
+        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=lenet_activation, name=\"S2\"),\n",
+        "    Conv2D(filters=16, kernel_size=(5, 5), activation=lenet_activation, name=\"C3\"),\n",
+        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=lenet_activation, name=\"S4\"),\n",
+        "    Flatten(),\n",
+        "    Dense(120, activation=lenet_activation, name=\"C5\"),\n",
+        "    Dense(84, activation=lenet_activation, name=\"F6\"),\n",
+        "    Dense(10, activation='softmax', name=\"Output\"),\n",
+        "], name=\"LeNet-5\")\n",
+        "\n",
+        "model.summary()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def scheduler(epoch: int, lr: float) -> float:\n",
+        "    if epoch < 2:\n",
+        "        eta = 0.0005\n",
+        "    elif epoch < 5:\n",
+        "        eta = 0.0002\n",
+        "    elif epoch < 8:\n",
+        "        eta = 0.0001\n",
+        "    elif epoch < 12:\n",
+        "        eta = 0.00005\n",
+        "    else:\n",
+        "        eta = 0.00001\n",
+        "\n",
+        "    mu = 0.02\n",
+        "    h_kk = 1\n",
+        "    return eta / (mu + h_kk)\n",
+        "\n",
+        "lr_callback = keras.callbacks.LearningRateScheduler(scheduler)"
+      ],
+      "metadata": {
+        "id": "bF7GGlO3EU7z"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Compile the model with optimizer and loss function.\n",
+        "opt = keras.optimizers.Adam(learning_rate=0.0005)\n",
+        "loss_fn = keras.losses.CategoricalCrossentropy()\n",
+        "model.compile(optimizer=opt, loss=loss_fn, metrics=['accuracy'])"
+      ],
+      "metadata": {
+        "id": "BenA0xmJA9_f"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "UM_tm3UfBSt9",
+        "outputId": "72a70f0a-947a-4fde-e646-8906ecfb5d5e"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Epoch 1/20\n",
+            "1875/1875 [==============================] - 19s 4ms/step - loss: 0.3454 - accuracy: 0.8910 - lr: 4.9020e-04\n",
+            "Epoch 2/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.1207 - accuracy: 0.9625 - lr: 4.9020e-04\n",
+            "Epoch 3/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0699 - accuracy: 0.9790 - lr: 1.9608e-04\n",
+            "Epoch 4/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0567 - accuracy: 0.9835 - lr: 1.9608e-04\n",
+            "Epoch 5/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0471 - accuracy: 0.9861 - lr: 1.9608e-04\n",
+            "Epoch 6/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0360 - accuracy: 0.9895 - lr: 9.8039e-05\n",
+            "Epoch 7/20\n",
+            "1875/1875 [==============================] - 8s 4ms/step - loss: 0.0320 - accuracy: 0.9908 - lr: 9.8039e-05\n",
+            "Epoch 8/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0288 - accuracy: 0.9919 - lr: 9.8039e-05\n",
+            "Epoch 9/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0242 - accuracy: 0.9937 - lr: 4.9020e-05\n",
+            "Epoch 10/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0227 - accuracy: 0.9941 - lr: 4.9020e-05\n",
+            "Epoch 11/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0214 - accuracy: 0.9948 - lr: 4.9020e-05\n",
+            "Epoch 12/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0201 - accuracy: 0.9950 - lr: 4.9020e-05\n",
+            "Epoch 13/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0177 - accuracy: 0.9961 - lr: 9.8039e-06\n",
+            "Epoch 14/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0173 - accuracy: 0.9961 - lr: 9.8039e-06\n",
+            "Epoch 15/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0170 - accuracy: 0.9963 - lr: 9.8039e-06\n",
+            "Epoch 16/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0167 - accuracy: 0.9963 - lr: 9.8039e-06\n",
+            "Epoch 17/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0165 - accuracy: 0.9964 - lr: 9.8039e-06\n",
+            "Epoch 18/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0163 - accuracy: 0.9965 - lr: 9.8039e-06\n",
+            "Epoch 19/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0161 - accuracy: 0.9966 - lr: 9.8039e-06\n",
+            "Epoch 20/20\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0158 - accuracy: 0.9966 - lr: 9.8039e-06\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Train the model\n",
+        "history = model.fit(x_train, y_train, epochs=20, callbacks=[lr_callback])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Evaluate the model\n",
+        "model.evaluate(x_test, y_test)"
+      ],
+      "metadata": {
+        "id": "-oORwhVmEbV_",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "2af11d0f-7160-45fd-8af1-fc95024353ec"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "313/313 [==============================] - 1s 3ms/step - loss: 0.0428 - accuracy: 0.9864\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[0.04284289851784706, 0.9864000082015991]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": null
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "LeNet [v3]: Subsamping, fixed scaling, and learning rate decay in Keras",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/lenet/README.md
+++ b/lenet/README.md
@@ -8,8 +8,9 @@ Available implementations:
 
 |     | Description    | Input<br/>pixel<br/>range | Pooling<br/>layer | Activation | Learning<br/>rate | Library | GitHub<br/>(readonly) | Colab | Binder |
 |:---:| -------------- |:-------------------------:|:-----------------:|:----------:|:-----------------:|:-------:|:---------------------:|:-----:|:------:|
-| v1 | Basic impl | [0, 1] | MaxPool2D | tanh | 0.001 | Keras | [![View on GitHub][github-badge]][github-basic] | [![Open In Colab][colab-badge]][colab-basic] | [![Open in Binder][binder-badge]][binder-basic] |
-| v2 | Custom layer,<br/>activation | [0, 1] | Subsampling | scaled<br/>tanh | 0.001 | Keras | [![View on GitHub][github-badge]][github-subsampling] | [![Open In Colab][colab-badge]][colab-subsampling] | [![Open in Binder][binder-badge]][binder-subsampling] |
+| v1 | Basic impl | [0, 1] | MaxPool2D | tanh | 0.001 | Keras | [![View on GitHub][github-badge]][github-keras-v1] | [![Open In Colab][colab-badge]][colab-keras-v1] | [![Open in Binder][binder-badge]][binder-keras-v1] |
+| v2 | Custom layer,<br/>activation | [0, 1] | Subsampling | scaled<br/>tanh | 0.001 | Keras | [![View on GitHub][github-badge]][github-keras-v2] | [![Open In Colab][colab-badge]][colab-keras-v2] | [![Open in Binder][binder-badge]][binder-keras-v2] |
+| v3 | Custom layer,<br/>activation,<br/>scaling,<br/>learning rate | [-0.1, 1.175] | Subsampling | scaled<br/>tanh | schedule | Keras | [![View on GitHub][github-badge]][github-keras-v3] | [![Open In Colab][colab-badge]][colab-keras-v3] | [![Open in Binder][binder-badge]][binder-keras-v3] |
 
 Our implementation is based on the following paper:
 
@@ -33,13 +34,17 @@ See also:
 [colab-badge]: https://colab.research.google.com/assets/colab-badge.svg
 [binder-badge]: https://static.mybinder.org/badge_logo.svg
 
-[github-basic]: LeNet_v1_basic_impl_in_Keras.ipynb
-[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
-[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+[github-keras-v1]: LeNet_v1_basic_impl_in_Keras.ipynb
+[colab-keras-v1]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+[binder-keras-v1]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v1_basic_impl_in_Keras.ipynb
 
-[github-subsampling]: LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
-[colab-subsampling]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
-[binder-subsampling]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+[github-keras-v2]: LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+[colab-keras-v2]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+[binder-keras-v2]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+
+[github-keras-v3]: LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+[colab-keras-v3]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+[binder-keras-v3]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
 
 [lenet-google-scholar]: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=WLN3QrAAAAAJ&citation_for_view=WLN3QrAAAAAJ:u5HHmVD_uO8C
 [lenet-wikipedia]: https://en.wikipedia.org/wiki/LeNet


### PR DESCRIPTION
Add LeNet v3 implementation in Keras, this time we scale the input to the
correct range [-0.1, 1.175] and add a learning rate decay schedule per the
paper.