### PR TITLE
Reset all notebook execution counts to `null`

### DIFF
--- a/alexnet/Basic_AlexNet_in_Keras.ipynb
+++ b/alexnet/Basic_AlexNet_in_Keras.ipynb
@@ -18,7 +18,7 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "id": "lVLBdJnv8SoF"
       },
@@ -52,7 +52,7 @@
       "metadata": {
         "id": "3uryURdO8Uws"
       },
-      "execution_count": 2,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -97,7 +97,7 @@
         "id": "JswAlt_l8qBC",
         "outputId": "3c1fe12b-5753-45ec-bdd7-fcba9a48c0de"
       },
-      "execution_count": 3,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",

--- a/googlenet/GoogLeNet_implementation_in_Keras.ipynb
+++ b/googlenet/GoogLeNet_implementation_in_Keras.ipynb
@@ -18,7 +18,7 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "id": "9eY2IqdkZfwM"
       },
@@ -52,7 +52,7 @@
       "metadata": {
         "id": "99ag8qASZrEF"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -128,7 +128,7 @@
       "metadata": {
         "id": "92nidAj7Z7Iy"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -192,7 +192,7 @@
         "id": "8cL7zNXKaLY0",
         "outputId": "ff08829e-c091-4ae2-d0c2-f2e3e1778cea"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",

--- a/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+++ b/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
@@ -2,7 +2,7 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "id": "-52CicmjShjz"
       },
@@ -25,7 +25,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "id": "OfRXb7AXBNoB"
       },
@@ -54,7 +54,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "id": "rEBeAvrWBQCU"
       },
@@ -66,7 +66,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -98,7 +98,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -132,7 +132,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -165,7 +165,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -213,7 +213,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -248,7 +248,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -308,7 +308,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": null,
       "metadata": {
         "id": "bF7GGlO3EU7z"
       },
@@ -322,7 +322,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -383,7 +383,7 @@
               "<keras.callbacks.History at 0x7f78d5a74bd0>"
             ]
           },
-          "execution_count": 11,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -395,7 +395,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": null,
       "metadata": {
         "id": "fTLNTNHUnyEm"
       },
@@ -413,7 +413,7 @@
               "[0.04807252436876297, 0.9879000186920166]"
             ]
           },
-          "execution_count": 12,
+          "execution_count": null,
           "metadata": {},
           "output_type": "execute_result"
         }

--- a/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+++ b/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
@@ -20,12 +20,12 @@
       "metadata": {
         "id": "-52CicmjShjz"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "id": "OfRXb7AXBNoB"
       },
@@ -40,7 +40,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "id": "LdXVAChTZu20"
       },
@@ -53,7 +53,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "id": "rEBeAvrWBQCU"
       },
@@ -80,7 +80,7 @@
         "id": "L9SC3sIaDv_i",
         "outputId": "9c3a7e32-ceaa-48aa-8722-4144b824f511"
       },
-      "execution_count": 4,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -127,7 +127,7 @@
         "id": "mhnNc_LSAoWh",
         "outputId": "79c07b44-baf6-4062-99be-a667c6e80177"
       },
-      "execution_count": 5,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -145,7 +145,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "id": "6oCDY6OEDrOp",
         "colab": {
@@ -189,12 +189,12 @@
       "metadata": {
         "id": "rSmV5tE911bM"
       },
-      "execution_count": 8,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "metadata": {
         "id": "eptAFMyWBD8L",
         "colab": {
@@ -262,12 +262,12 @@
       "metadata": {
         "id": "BenA0xmJA9_f"
       },
-      "execution_count": 10,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -330,7 +330,7 @@
             ]
           },
           "metadata": {},
-          "execution_count": 11
+          "execution_count": null
         }
       ],
       "source": [
@@ -351,7 +351,7 @@
         },
         "outputId": "0295e999-5d1c-44a8-d3ea-add07e3d0792"
       },
-      "execution_count": 12,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -368,7 +368,7 @@
             ]
           },
           "metadata": {},
-          "execution_count": 12
+          "execution_count": null
         }
       ]
     }

--- a/vgg/Basic_VGG_in_Keras.ipynb
+++ b/vgg/Basic_VGG_in_Keras.ipynb
@@ -17,7 +17,7 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "id": "Cd6PrIjsrx2d"
       },
@@ -48,7 +48,7 @@
       "metadata": {
         "id": "wxCnecJqr2LP"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -79,7 +79,7 @@
       "metadata": {
         "id": "k5eXee6L5SBs"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -96,7 +96,7 @@
       "metadata": {
         "id": "dv3LqkRc5Woo"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -185,7 +185,7 @@
       "metadata": {
         "id": "0feiTuI5r4G0"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -201,7 +201,7 @@
       "metadata": {
         "id": "5T3pkvY_151d"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -216,7 +216,7 @@
         "id": "LM2znmml0AZX",
         "outputId": "5d6b58e8-de07-4309-984c-cf4aa16622ff"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -283,7 +283,7 @@
         "id": "Ka4dmIKK0D3z",
         "outputId": "d704762d-4eed-45fa-9080-0d03331906c1"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -350,7 +350,7 @@
         "id": "YkDUZ1Yr0EYe",
         "outputId": "3ab0cc76-4c98-4be8-8130-1ae807ae68a8"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -421,7 +421,7 @@
         "id": "evyOFgiD0GVI",
         "outputId": "41107897-9384-4920-ba04-26061295a61a"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -498,7 +498,7 @@
         "id": "RkgGL2lZ0GK4",
         "outputId": "d7028b36-b5d0-44a5-c5b5-d3e741609820"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -575,7 +575,7 @@
         "id": "o2BKw_OM0Fvh",
         "outputId": "206e2a85-7ac3-451b-c67e-c2a2356f529d"
       },
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",


### PR DESCRIPTION
This makes it easy to keep the execution count consistent, as we can always do a
global search-and-replace to change the numbers to `null`, and we don't have to
worry about spurious changes in the cell metadata blocks.