### PR TITLE
Add links to Colab and Binder; add use of einops

### DIFF
--- a/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+++ b/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
@@ -24,6 +24,27 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BCsCeBGtx4Uo"
+      },
+      "source": [
+        "If you're viewing this notebook on GitHub, where it is read-only, you can click any of the buttons below to open this notebook in one of the interactive online notebook environments:\n",
+        "\n",
+        "| Colab | Binder |\n",
+        "|-------|--------|\n",
+        "| [![Open In Colab][colab-badge]][colab-keras-v1] | [![Open in Binder][binder-badge]][binder-keras-v1] |\n",
+        "\n",
+        "You can also download and run this notebook locally.\n",
+        "\n",
+        "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
+        "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
+        "\n",
+        "[colab-keras-v1]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v1_basic_impl_in_Keras.ipynb\n",
+        "[binder-keras-v1]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v1_basic_impl_in_Keras.ipynb"
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -37,6 +58,18 @@
         "from keras import Input, Sequential\n",
         "from keras.layers import AveragePooling2D, MaxPooling2D, Conv2D, Dense, Flatten\n",
         "from matplotlib import pyplot as plt"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "YHdoEW6wypv2"
+      },
+      "outputs": [],
+      "source": [
+        "%pip install -q -U 'einops==0.4'\n",
+        "import einops"
       ]
     },
     {
@@ -190,10 +223,20 @@
       "source": [
         "num_classes = 10\n",
         "\n",
-        "# Expand the dimensions of our inputs to ensure their shape is (28, 28, 1),\n",
-        "# rather than (28, 28) which is what they are by default.\n",
-        "x_train = np.expand_dims(x_train_raw, -1)\n",
-        "x_test = np.expand_dims(x_test_raw, -1)\n",
+        "# Add a channel dimension so that our inputs have the dimension (28, 28, 1)\n",
+        "# rather than (28, 28). This is done by converting our input of\n",
+        "# (batch, width, height) -> (batch, width, height, channels) with channels=1.\n",
+        "#\n",
+        "# In this specific case, this reshapes (60000, 28, 28) -> (60000, 28, 28, 1).\n",
+        "#\n",
+        "# Although this is similar to expanding dimensions via NumPy as follows:\n",
+        "#\n",
+        "#     x_train = np.expand_dims(x_train_raw, -1)\n",
+        "#     x_test = np.expand_dims(x_test_raw, -1)\n",
+        "#\n",
+        "# the approach with `einops` makes it much more readable and understandable.\n",
+        "x_train = einops.rearrange(x_train_raw, 'b w h -> b w h ()')\n",
+        "x_test = einops.rearrange(x_test_raw, 'b w h -> b w h ()')\n",
         "\n",
         "# Scale train and test inputs by converting them from range of [0, 255] to [0.0, 1.0]\n",
         "x_train = x_train.astype('float32') / 255.0\n",

--- a/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+++ b/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
@@ -24,6 +24,27 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-eOWhArxahUl"
+      },
+      "source": [
+        "If you're viewing this notebook on GitHub, where it is read-only, you can click any of the buttons below to open this notebook in one of the interactive online notebook environments:\n",
+        "\n",
+        "| Colab | Binder |\n",
+        "|-------|--------|\n",
+        "| [![Open In Colab][colab-badge]][colab-keras-v2] | [![Open in Binder][binder-badge]][binder-keras-v2] |\n",
+        "\n",
+        "You can also download and run this notebook locally.\n",
+        "\n",
+        "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
+        "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
+        "\n",
+        "[colab-keras-v2]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb\n",
+        "[binder-keras-v2]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb"
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -49,6 +70,18 @@
         "# Download and import custom Subsampling layer.\n",
         "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
         "from subsampling import Subsampling"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "kuwdrBW1assu"
+      },
+      "outputs": [],
+      "source": [
+        "%pip install -q -U 'einops==0.4'\n",
+        "import einops"
       ]
     },
     {
@@ -122,10 +155,20 @@
       "source": [
         "num_classes = 10\n",
         "\n",
-        "# Expand the dimensions of our inputs to ensure their shape is (28, 28, 1),\n",
-        "# rather than (28, 28) which is what they are by default.\n",
-        "x_train = np.expand_dims(x_train_raw, -1)\n",
-        "x_test = np.expand_dims(x_test_raw, -1)\n",
+        "# Add a channel dimension so that our inputs have the dimension (28, 28, 1)\n",
+        "# rather than (28, 28). This is done by converting our input of\n",
+        "# (batch, width, height) -> (batch, width, height, channels) with channels=1.\n",
+        "#\n",
+        "# In this specific case, this reshapes (60000, 28, 28) -> (60000, 28, 28, 1).\n",
+        "#\n",
+        "# Although this is similar to expanding dimensions via NumPy as follows:\n",
+        "#\n",
+        "#     x_train = np.expand_dims(x_train_raw, -1)\n",
+        "#     x_test = np.expand_dims(x_test_raw, -1)\n",
+        "#\n",
+        "# the approach with `einops` makes it much more readable and understandable.\n",
+        "x_train = einops.rearrange(x_train_raw, 'b w h -> b w h ()')\n",
+        "x_test = einops.rearrange(x_test_raw, 'b w h -> b w h ()')\n",
         "\n",
         "# Scale train and test inputs by converting them from range of [0, 255] to [0.0, 1.0]\n",
         "x_train = x_train_raw.astype('float32') / 255.0\n",

--- a/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+++ b/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
@@ -24,6 +24,27 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "N1mFS_HkbTNG"
+      },
+      "source": [
+        "If you're viewing this notebook on GitHub, where it is read-only, you can click any of the buttons below to open this notebook in one of the interactive online notebook environments:\n",
+        "\n",
+        "| Colab | Binder |\n",
+        "|-------|--------|\n",
+        "| [![Open In Colab][colab-badge]][colab-keras-v3] | [![Open in Binder][binder-badge]][binder-keras-v3] |\n",
+        "\n",
+        "You can also download and run this notebook locally.\n",
+        "\n",
+        "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
+        "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
+        "\n",
+        "[colab-keras-v3]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb\n",
+        "[binder-keras-v3]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb"
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -49,6 +70,18 @@
         "# Download and import custom Subsampling layer.\n",
         "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
         "from subsampling import Subsampling"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "IHNgGn3ZbQw4"
+      },
+      "outputs": [],
+      "source": [
+        "%pip install -q -U 'einops==0.4'\n",
+        "import einops"
       ]
     },
     {
@@ -136,16 +169,26 @@
       "source": [
         "num_classes = 10\n",
         "\n",
-        "# Expand the dimensions of our inputs to ensure their shape is (28, 28, 1),\n",
-        "# rather than (28, 28) which is what they are by default.\n",
-        "x_train = np.expand_dims(x_train_raw, -1)\n",
-        "x_test = np.expand_dims(x_test_raw, -1)\n",
+        "# Add a channel dimension so that our inputs have the dimension (28, 28, 1)\n",
+        "# rather than (28, 28). This is done by converting our input of\n",
+        "# (batch, width, height) -> (batch, width, height, channels) with channels=1.\n",
+        "#\n",
+        "# In this specific case, this reshapes (60000, 28, 28) -> (60000, 28, 28, 1).\n",
+        "#\n",
+        "# Although this is similar to expanding dimensions via NumPy as follows:\n",
+        "#\n",
+        "#     x_train = np.expand_dims(x_train_raw, -1)\n",
+        "#     x_test = np.expand_dims(x_test_raw, -1)\n",
+        "#\n",
+        "# the approach with `einops` makes it much more readable and understandable.\n",
+        "x_train = einops.rearrange(x_train_raw, 'b w h -> b w h ()')\n",
+        "x_test = einops.rearrange(x_test_raw, 'b w h -> b w h ()')\n",
         "\n",
         "# Scale train and test inputs by converting them from range of [0, 255] to\n",
         "# [-0.1, 1.175]. From the LeNet paper, pg. 7:\n",
         "#\n",
         "#     \"The values of the input pixels are normalized so that the background level\n",
-        "#      white\b corresponds to a value of -0.1 and the foreground black\b corresponds\n",
+        "#      white corresponds to a value of -0.1 and the foreground black corresponds\n",
         "#      to 1.175. This makes the mean input roughly 0 and the variance roughly 1\n",
         "#      which accelerates learning.\"\n",
         "lower_bound = -0.1\n",


### PR DESCRIPTION
If these notebooks are viewed on GitHub, they are view-only and cannot be run.
Although we provide links in the README to open them in Colab and Binder, folks
who get a direct link to a notebook from outside of the repo, or folks who
quickly open a notebook may not have the links to open the notebook in those
services.

Make it trivial to open a runnable version of each notebook by embedding buttons
to open a notebook in either service.

Also, use `einops` for a more intuitive way to expand dimensions of the image
inputs rather than an unintuitive syntax of `np.expand_dims()`.