### PR TITLE
Combine notebook badges into a single cell

### DIFF
--- a/alexnet/README.md
+++ b/alexnet/README.md
@@ -6,9 +6,9 @@ with the ImageNet dataset.
 
 Available implementations:
 
-|      | Description    | Library | GitHub<br/>(readonly) | Colab | Binder |
-|:----:| -------------- |:-------:|:---------------------:|:-----:|:------:|
-|  v1  | Basic impl     |  Keras  | [![View on GitHub][github-badge]][github-basic] | [![Open In Colab][colab-badge]][colab-basic] | [![Open in Binder][binder-badge]][binder-basic] |
+|      | Description    | Library | Notebook |
+|:----:| -------------- |:-------:|:--------:|
+|  v1  | Basic impl     |  Keras  | [![View on GitHub][github-badge]][github-basic] [![Open In Colab][colab-badge]][colab-basic] [![Open in Binder][binder-badge]][binder-basic] |
 
 Implementation notes for v1:
 

--- a/googlenet/README.md
+++ b/googlenet/README.md
@@ -12,9 +12,9 @@ and implement the network. See the directory's documentation for details.
 
 Available implementations:
 
-|      | Description    | Library | GitHub<br/>(readonly) | Colab | Binder |
-|:----:| -------------- |:-------:|:---------------------:|:-----:|:------:|
-|  v1  | Basic impl     |  Keras  | [![View on GitHub][github-badge]][github-basic] | [![Open In Colab][colab-badge]][colab-basic] | [![Open in Binder][binder-badge]][binder-basic] |
+|      | Description    | Library | Notebook |
+|:----:| -------------- |:-------:|:--------:|
+|  v1  | Basic impl     |  Keras  | [![View on GitHub][github-badge]][github-basic] [![Open In Colab][colab-badge]][colab-basic] [![Open in Binder][binder-badge]][binder-basic] |
 
 Implementation notes for v1:
 

--- a/lenet/README.md
+++ b/lenet/README.md
@@ -6,11 +6,11 @@ Neural Network (CNN) used for character recognition, trained and tested with the
 
 Available implementations:
 
-|     | Description    | Input<br/>pixel<br/>range | Pooling<br/>layer | Activation | Learning<br/>rate | Library | GitHub<br/>(readonly) | Colab | Binder |
-|:---:| -------------- |:-------------------------:|:-----------------:|:----------:|:-----------------:|:-------:|:---------------------:|:-----:|:------:|
-| v1 | Basic impl | [0, 1] | MaxPool2D | tanh | 0.001 | Keras | [![View on GitHub][github-badge]][github-keras-v1] | [![Open In Colab][colab-badge]][colab-keras-v1] | [![Open in Binder][binder-badge]][binder-keras-v1] |
-| v2 | Custom layer,<br/>activation | [0, 1] | Subsampling | scaled<br/>tanh | 0.001 | Keras | [![View on GitHub][github-badge]][github-keras-v2] | [![Open In Colab][colab-badge]][colab-keras-v2] | [![Open in Binder][binder-badge]][binder-keras-v2] |
-| v3 | Custom layer,<br/>activation,<br/>scaling,<br/>learning rate | [-0.1, 1.175] | Subsampling | scaled<br/>tanh | schedule | Keras | [![View on GitHub][github-badge]][github-keras-v3] | [![Open In Colab][colab-badge]][colab-keras-v3] | [![Open in Binder][binder-badge]][binder-keras-v3] |
+|     | Description    | Input<br/>pixel<br/>range | Pooling<br/>layer | Activation | Learning<br/>rate | Library | Notebook |
+|:---:| -------------- |:-------------------------:|:-----------------:|:----------:|:-----------------:|:-------:|:--------:|
+| v1 | Basic impl | [0, 1] | MaxPool2D | tanh | 0.001 | Keras | [![View on GitHub][github-badge]][github-keras-v1] [![Open In Colab][colab-badge]][colab-keras-v1] [![Open in Binder][binder-badge]][binder-keras-v1] |
+| v2 | Custom layer,<br/>activation | [0, 1] | Subsampling | scaled<br/>tanh | 0.001 | Keras | [![View on GitHub][github-badge]][github-keras-v2] [![Open In Colab][colab-badge]][colab-keras-v2] [![Open in Binder][binder-badge]][binder-keras-v2] |
+| v3 | Custom layer,<br/>activation,<br/>scaling,<br/>learning rate | [-0.1, 1.175] | Subsampling | scaled<br/>tanh | schedule | Keras | [![View on GitHub][github-badge]][github-keras-v3] [![Open In Colab][colab-badge]][colab-keras-v3] [![Open in Binder][binder-badge]][binder-keras-v3] |
 
 Our implementation is based on the following paper:
 

--- a/vgg/README.md
+++ b/vgg/README.md
@@ -6,9 +6,9 @@ and VGG-19 models, to be tested with the ImageNet dataset.
 
 Available implementations:
 
-|      | Description    | Library | GitHub<br/>(readonly) | Colab | Binder |
-|:----:| -------------- |:-------:|:---------------------:|:-----:|:------:|
-|  v1  | Basic impl     |  Keras  | [![View on GitHub][github-badge]][github-basic] | [![Open In Colab][colab-badge]][colab-basic] | [![Open in Binder][binder-badge]][binder-basic] |
+|      | Description    | Library | Notebook |
+|:----:| -------------- |:-------:|:--------:|
+|  v1  | Basic impl     |  Keras  | [![View on GitHub][github-badge]][github-basic] [![Open In Colab][colab-badge]][colab-basic] [![Open in Binder][binder-badge]][binder-basic] |
 
 Implementation notes for v1:
 


### PR DESCRIPTION
With large tables, as the number of cells in a row increases, the badges have
less space and are shrunk to fit, which reduces their readability. By combining
them all into a single cell, they will wrap, taking up the space of a single
badge horizontally, which will keep them readable with larger numbers of cells
per row.