### PR TITLE
Add GitHub, Colab, and Binder badges to notebooks

### DIFF
--- a/alexnet/Basic_AlexNet_in_Keras.ipynb
+++ b/alexnet/Basic_AlexNet_in_Keras.ipynb
@@ -24,6 +24,23 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "source": [
+        "[![View on GitHub][github-badge]][github-basic] [![Open In Colab][colab-badge]][colab-basic] [![Open in Binder][binder-badge]][binder-basic]\n",
+        "\n",
+        "[github-badge]: https://img.shields.io/badge/View-on%20GitHub-blue?logo=GitHub\n",
+        "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
+        "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
+        "\n",
+        "[github-basic]: Basic_AlexNet_in_Keras.ipynb\n",
+        "[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/alexnet/Basic_AlexNet_in_Keras.ipynb\n",
+        "[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=alexnet/Basic_AlexNet_in_Keras.ipynb"
+      ],
+      "metadata": {
+        "id": "XzSflOuiSkLr"
+      }
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {

--- a/googlenet/GoogLeNet_implementation_in_Keras.ipynb
+++ b/googlenet/GoogLeNet_implementation_in_Keras.ipynb
@@ -24,6 +24,23 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "source": [
+        "[![View on GitHub][github-badge]][github-basic] [![Open In Colab][colab-badge]][colab-basic] [![Open in Binder][binder-badge]][binder-basic]\n",
+        "\n",
+        "[github-badge]: https://img.shields.io/badge/View-on%20GitHub-blue?logo=GitHub\n",
+        "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
+        "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
+        "\n",
+        "[github-basic]: GoogLeNet_implementation_in_Keras.ipynb\n",
+        "[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/googlenet/GoogLeNet_implementation_in_Keras.ipynb\n",
+        "[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=googlenet/GoogLeNet_implementation_in_Keras.ipynb"
+      ],
+      "metadata": {
+        "id": "0s8AuNQQSyrd"
+      }
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {

--- a/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+++ b/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
@@ -29,17 +29,13 @@
         "id": "BCsCeBGtx4Uo"
       },
       "source": [
-        "If you're viewing this notebook on GitHub, where it is read-only, you can click any of the buttons below to open this notebook in one of the interactive online notebook environments:\n",
+        "[![View on GitHub][github-badge]][github-keras-v1] [![Open In Colab][colab-badge]][colab-keras-v1] [![Open in Binder][binder-badge]][binder-keras-v1]\n",
         "\n",
-        "| Colab | Binder |\n",
-        "|-------|--------|\n",
-        "| [![Open In Colab][colab-badge]][colab-keras-v1] | [![Open in Binder][binder-badge]][binder-keras-v1] |\n",
-        "\n",
-        "You can also download and run this notebook locally.\n",
-        "\n",
+        "[github-badge]: https://img.shields.io/badge/View-on%20GitHub-blue?logo=GitHub\n",
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
+        "[github-keras-v1]: LeNet_v1_basic_impl_in_Keras.ipynb\n",
         "[colab-keras-v1]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v1_basic_impl_in_Keras.ipynb\n",
         "[binder-keras-v1]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v1_basic_impl_in_Keras.ipynb"
       ]

--- a/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+++ b/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
@@ -29,17 +29,13 @@
         "id": "-eOWhArxahUl"
       },
       "source": [
-        "If you're viewing this notebook on GitHub, where it is read-only, you can click any of the buttons below to open this notebook in one of the interactive online notebook environments:\n",
+        "[![View on GitHub][github-badge]][github-keras-v2] [![Open In Colab][colab-badge]][colab-keras-v2] [![Open in Binder][binder-badge]][binder-keras-v2]\n",
         "\n",
-        "| Colab | Binder |\n",
-        "|-------|--------|\n",
-        "| [![Open In Colab][colab-badge]][colab-keras-v2] | [![Open in Binder][binder-badge]][binder-keras-v2] |\n",
-        "\n",
-        "You can also download and run this notebook locally.\n",
-        "\n",
+        "[github-badge]: https://img.shields.io/badge/View-on%20GitHub-blue?logo=GitHub\n",
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
+        "[github-keras-v2]: LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb\n",
         "[colab-keras-v2]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb\n",
         "[binder-keras-v2]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb"
       ]

--- a/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+++ b/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
@@ -29,17 +29,13 @@
         "id": "N1mFS_HkbTNG"
       },
       "source": [
-        "If you're viewing this notebook on GitHub, where it is read-only, you can click any of the buttons below to open this notebook in one of the interactive online notebook environments:\n",
+        "[![View on GitHub][github-badge]][github-keras-v3] [![Open In Colab][colab-badge]][colab-keras-v3] [![Open in Binder][binder-badge]][binder-keras-v3]\n",
         "\n",
-        "| Colab | Binder |\n",
-        "|-------|--------|\n",
-        "| [![Open In Colab][colab-badge]][colab-keras-v3] | [![Open in Binder][binder-badge]][binder-keras-v3] |\n",
-        "\n",
-        "You can also download and run this notebook locally.\n",
-        "\n",
+        "[github-badge]: https://img.shields.io/badge/View-on%20GitHub-blue?logo=GitHub\n",
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
+        "[github-keras-v3]: LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb\n",
         "[colab-keras-v3]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb\n",
         "[binder-keras-v3]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb"
       ]

--- a/vgg/Basic_VGG_in_Keras.ipynb
+++ b/vgg/Basic_VGG_in_Keras.ipynb
@@ -24,6 +24,23 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "source": [
+        "[![View on GitHub][github-badge]][github-basic] [![Open In Colab][colab-badge]][colab-basic] [![Open in Binder][binder-badge]][binder-basic]\n",
+        "\n",
+        "[github-badge]: https://img.shields.io/badge/View-on%20GitHub-blue?logo=GitHub\n",
+        "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
+        "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
+        "\n",
+        "[github-basic]: Basic_VGG_in_Keras.ipynb\n",
+        "[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/vgg/Basic_VGG_in_Keras.ipynb\n",
+        "[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=vgg/Basic_VGG_in_Keras.ipynb"
+      ],
+      "metadata": {
+        "id": "e22OwcveTAtP"
+      }
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {


### PR DESCRIPTION
Simplify existing introductions to limit them to just badges with links to
notebooks for clarity and simplicity.