### PR TITLE
Add notebook canonicalization script and test

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[BUILD,*.bzl,*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Checks & tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout the repo
+      uses: actions/checkout@v3
+
+    - name: Run notebook format test
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERB = @
+ifeq ($(VERBOSE),1)
+	VERB =
+endif
+
+.PHONY: test clean
+
+test: nbfmt-test
+
+nbfmt-test: run_nbfmt_test.sh Makefile
+	$(VERB) ./$<
+
+update: nbfmt-update
+
+nbfmt-update: nbfmt_update.sh Makefile
+	$(VERB) ./$<

--- a/nbfmt.py
+++ b/nbfmt.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Canonicalizes field ordering and values in Jupyter notebooks.
+
+This enables minimal human-reviewable diffs from one version to the next, even
+when updated in various tools like Colab, VS Code, etc., each of which make
+their own choices in various regards like field ordering, add or update
+inconsequential fields and their values, leading to spurious diffs that obscure
+the real changes.
+"""
+
+import json
+import sys
+from typing import Dict, List
+
+
+EXECUTION_COUNT = 'execution_count'
+
+
+def processList(data: List):
+    """Processes the passed-in list recursively, may modify it in-place."""
+    for item in data:
+        if isinstance(item, list):
+            processList(item)
+        elif isinstance(item, dict):
+            processDict(item)
+
+
+def processDict(data: Dict):
+    """Processes the passed-in dict recursively, may modify it in-place."""
+    # Reset execution counts for code cells.
+    if EXECUTION_COUNT in data:
+        data[EXECUTION_COUNT] = None
+
+    for key in data.keys():
+        if isinstance(data[key], list):
+            processList(data[key])
+        elif isinstance(data[key], dict):
+            processDict(data[key])
+
+
+# TODO(mbrukman): add flag `-w` to rewrite the file in-place, a la gofmt.
+def main(argv):
+    """Parses notebook and outputs canonicalized version to stdout."""
+    if len(argv) < 2:
+        sys.stderr.write(f'Syntax: {argv[0]} [path-to-notebook]\n')
+        sys.exit(1)
+
+    notebook = argv[1]
+    json_input = None
+    with open(notebook, 'r') as json_file:
+        json_input = json.loads(json_file.read())
+
+    # Updates the JSON in-place.
+    processDict(json_input)
+
+    # Apply a few more canonicalization rules:
+    #
+    # * avoid newline at the end of file;
+    # * `sort_keys` fixes field ordering inside JSON objects;
+    # * use 2-space indent.
+    sys.stdout.write(json.dumps(json_input, sort_keys=True, indent=2))
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/nbfmt_update.sh
+++ b/nbfmt_update.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -u
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function clean_file() {
+  local file="$1"
+  local temp="${file}.tmp"
+
+  echo -n "Updating ${file} ... "
+  python "$(dirname $0)/nbfmt.py" "${file}" > "${temp}"
+  if diff "${file}" "${temp}" > /dev/null 2>&1; then
+    rm "${temp}"
+    echo "no change."
+  else
+    mv "${temp}" "${file}"
+    echo "done."
+  fi
+}
+
+for file in $(find -s . -name \*\.ipynb); do
+  clean_file "${file}"
+done

--- a/run_nbfmt_test.sh
+++ b/run_nbfmt_test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -u
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare -i status=0
+
+function test_file() {
+  local file="$1"
+  local temp="${file}.tmp"
+  local diff="${file}.diff"
+
+  echo -n "Testing ${file} ... "
+  python "$(dirname $0)/nbfmt.py" "${file}" > "${temp}"
+  if diff -u "${file}" "${temp}" > "${diff}" 2>&1; then
+    echo "no diff."
+  else
+    status=1
+    echo "found diff:"
+    echo
+    cat "${diff}"
+    echo
+  fi
+  rm "${temp}" "${diff}"
+}
+
+for file in $(find . -name \*\.ipynb); do
+  test_file "${file}"
+done
+
+echo
+if [ ${status} -eq 0 ]; then
+  echo "PASSED"
+else
+  echo "FAILED"
+fi
+
+exit ${status}


### PR DESCRIPTION
This meakes it easy to reformat all notebooks in the repo with a single command,
as well as ensure that we keep the notebooks well-formatted to avoid spurious
diffs now and in the future, by making it part of the pre-commit testing.