### PR TITLE
Build GoogLeNet SVG diagrams in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,3 +32,16 @@ jobs:
 
     - name: Run notebook format test
       run: make test
+
+    - name: Install tools for building SVG diagrams
+      run: |
+        sudo apt update
+        sudo apt install graphviz m4
+
+    - name: Build GoogLeNet SVG diagrams
+      run: |
+        cd googlenet/diagrams
+        # The SVG files are checked-in for convenience; delete them to force
+        # `make` to regenerate them, so we're not depending on timestamps.
+        rm -f *.svg
+        make all VERBOSE=1


### PR DESCRIPTION
Ensure that the diagrams continue to build buildable. Also install `m4` and `dot` as they are necessary prerequisites for building these diagrams, and clear out the directory of all SVGs before running the build.

The SVGs are currently checked-in so that we can display them properly with the stylesheet on the published website; not deleting them would require that the timestamps on the `*.m4` files would be newer than the SVG files, which we cannot gaurantee, since the checked-in SVG files would have been created after the relevant input files, so this step would never actually run in the CI environment.