### PR TITLE
Remove unneeded fields from Jupyter notebooks

### DIFF
--- a/alexnet/AlexNet_for_CIFAR-10_in_Keras_with_tf_nn_LocalResponseNormalization.ipynb
+++ b/alexnet/AlexNet_for_CIFAR-10_in_Keras_with_tf_nn_LocalResponseNormalization.ipynb
@@ -2,11 +2,9 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "4zLuzkUgnLrK"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -25,11 +23,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "9szn5TsGnVCT"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import tensorflow as tf\n",
@@ -41,11 +37,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "ji9t1O8sU3Xb"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/local_response_normalization.py\n",
         "\n",
@@ -54,13 +48,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "nmuynEz5nw_x",
-        "outputId": "905caf0c-cbb1-466e-d51c-7ee899ebc120"
+        "id": null
       },
       "outputs": [
         {
@@ -80,11 +69,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "RKByh8Ber805"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "num_classes = 10\n",
         "\n",
@@ -100,13 +87,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "8WbwCWBentil",
-        "outputId": "66c9003f-dd19-46c7-b431-9d1c080c60cf"
+        "id": null
       },
       "outputs": [
         {
@@ -170,11 +152,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "zqDedv8RvIHE"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Compile the model with optimizer and loss function.\n",
         "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
@@ -184,13 +164,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "nprurN1dvK5-",
-        "outputId": "517377e0-94ed-4b09-d750-b183feaed83c"
+        "id": null
       },
       "outputs": [
         {
@@ -245,8 +220,6 @@
               "<keras.callbacks.History at 0x7fb8c04226d0>"
             ]
           },
-          "execution_count": null,
-          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -257,13 +230,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "GXtV8JJbvMlj",
-        "outputId": "77fcf827-6247-4ca6-ddbe-930b6548a43d"
+        "id": null
       },
       "outputs": [
         {
@@ -279,8 +247,6 @@
               "[1.2246522903442383, 0.7002999782562256]"
             ]
           },
-          "execution_count": null,
-          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -292,10 +258,6 @@
   ],
   "metadata": {
     "accelerator": "TPU",
-    "colab": {
-      "collapsed_sections": [],
-      "provenance": []
-    },
     "kernelspec": {
       "display_name": "Python 3",
       "name": "python3"

--- a/alexnet/AlexNet_for_CIFAR-10_with_Pylearn2_Keras_LRN.ipynb
+++ b/alexnet/AlexNet_for_CIFAR-10_with_Pylearn2_Keras_LRN.ipynb
@@ -2,11 +2,9 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "4zLuzkUgnLrK"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -25,11 +23,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "9szn5TsGnVCT"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import tensorflow as tf\n",
@@ -41,11 +37,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "1gwzY0NpJzfB"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Download the Pylearn2/Keras implementation of LocalResponseNormalization.\n",
         "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/third_party/pylearn2/local_response_normalization.py\n",
@@ -55,13 +49,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "nmuynEz5nw_x",
-        "outputId": "ae5ae84a-644d-4e3d-81f9-8d4799d79018"
+        "id": null
       },
       "outputs": [
         {
@@ -81,11 +70,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "RKByh8Ber805"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "num_classes = 10\n",
         "\n",
@@ -101,13 +88,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "8WbwCWBentil",
-        "outputId": "c79b050f-dc0a-43d5-d938-2c905752a547"
+        "id": null
       },
       "outputs": [
         {
@@ -169,11 +151,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "zqDedv8RvIHE"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Compile the model with optimizer and loss function.\n",
         "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
@@ -183,13 +163,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "nprurN1dvK5-",
-        "outputId": "f2f406e1-50fb-4292-efe6-679d322514e4"
+        "id": null
       },
       "outputs": [
         {
@@ -244,8 +219,6 @@
               "<keras.callbacks.History at 0x7f4a7e7a5850>"
             ]
           },
-          "execution_count": null,
-          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -256,13 +229,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "GXtV8JJbvMlj",
-        "outputId": "d0a5ec70-1f0f-43b8-de59-11076646f694"
+        "id": null
       },
       "outputs": [
         {
@@ -278,8 +246,6 @@
               "[1.3027948141098022, 0.6922000050544739]"
             ]
           },
-          "execution_count": null,
-          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -291,10 +257,6 @@
   ],
   "metadata": {
     "accelerator": "TPU",
-    "colab": {
-      "collapsed_sections": [],
-      "provenance": []
-    },
     "kernelspec": {
       "display_name": "Python 3",
       "name": "python3"

--- a/alexnet/Basic_AlexNet_in_Keras.ipynb
+++ b/alexnet/Basic_AlexNet_in_Keras.ipynb
@@ -2,11 +2,9 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "lVLBdJnv8SoF"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -26,7 +24,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "XzSflOuiSkLr"
+        "id": null
       },
       "source": [
         "[![View on GitHub][github-badge]][github-basic] [![Open In Colab][colab-badge]][colab-basic] [![Open in Binder][binder-badge]][binder-basic]\n",
@@ -42,11 +40,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "3uryURdO8Uws"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import tensorflow as tf\n",
@@ -59,7 +55,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "pQIxFUn25W8J"
+        "id": null
       },
       "source": [
         "This simple implementation does not split the data across 2 GPUs as described in the original paper for simplicity of implementation. It also does not include the custom response normalization layers (see the `TODO`s in the model below for where they should appear)."
@@ -67,13 +63,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "JswAlt_l8qBC",
-        "outputId": "3c1fe12b-5753-45ec-bdd7-fcba9a48c0de"
+        "id": null
       },
       "outputs": [
         {
@@ -148,9 +139,7 @@
   ],
   "metadata": {
     "colab": {
-      "collapsed_sections": [],
-      "name": "Basic AlexNet in Keras",
-      "provenance": []
+      "name": "Basic AlexNet in Keras"
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/datasets/cifar-10/CIFAR-10_-_Exploratory_Data_Analysis.ipynb
+++ b/datasets/cifar-10/CIFAR-10_-_Exploratory_Data_Analysis.ipynb
@@ -2,11 +2,6 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "4zLuzkUgnLrK"
-      },
-      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -25,9 +20,6 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "S37sEkJcrLsA"
-      },
       "source": [
         "[![View on GitHub][github-badge]][github-eda] [![Open In Colab][colab-badge]][colab-eda] [![Open in Binder][binder-badge]][binder-eda]\n",
         "\n",
@@ -42,11 +34,6 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "9szn5TsGnVCT"
-      },
-      "outputs": [],
       "source": [
         "from tensorflow import keras\n",
         "from matplotlib import pyplot as plt"
@@ -54,11 +41,6 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "nmuynEz5nw_x"
-      },
-      "outputs": [],
       "source": [
         "# Load the CIFAR-10 dataset.\n",
         "(x_train_raw, y_train_raw), (x_test_raw, y_test_raw) = keras.datasets.cifar10.load_data();"
@@ -66,11 +48,6 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "mcpr_GOup-px"
-      },
-      "outputs": [],
       "source": [
         "# Examine the dataset shape.\n",
         "print(\"Raw data:\")\n",
@@ -82,11 +59,6 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "126r8FbaqQm8"
-      },
-      "outputs": [],
       "source": [
         "# Let's see what some of the training images and raw input data look like.\n",
         "fig = plt.figure(figsize=(8, 8))\n",
@@ -101,22 +73,12 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "R5wQIZ4ps7Zo"
-      },
-      "outputs": [],
       "source": [
         "print(\"Raw x train:\\n\", x_train_raw[0, :])"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "HrwmkTOZuljH"
-      },
-      "outputs": [],
       "source": [
         "print(f\"X train raw stats: min={x_train_raw.min()}, max={x_train_raw.max()}\")\n",
         "print(f\"X test  raw stats: min={x_test_raw.min()}, max={x_test_raw.max()}\")"
@@ -124,11 +86,6 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "RKByh8Ber805"
-      },
-      "outputs": [],
       "source": [
         "num_classes = 10\n",
         "\n",
@@ -144,22 +101,12 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "4n0iZJEbtJUs"
-      },
-      "outputs": [],
       "source": [
         "print(\"Processed x train:\\n\", x_train[0, :])"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "OZj6U4ozsvcj"
-      },
-      "outputs": [],
       "source": [
         "print(\"Raw y train:\", y_train_raw[0])\n",
         "print(\"Processed y train:\", y_train[0])"
@@ -168,10 +115,6 @@
   ],
   "metadata": {
     "accelerator": "TPU",
-    "colab": {
-      "collapsed_sections": [],
-      "provenance": []
-    },
     "kernelspec": {
       "display_name": "Python 3",
       "name": "python3"

--- a/googlenet/GoogLeNet_implementation_in_Keras.ipynb
+++ b/googlenet/GoogLeNet_implementation_in_Keras.ipynb
@@ -2,11 +2,9 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "9eY2IqdkZfwM"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -26,7 +24,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "0s8AuNQQSyrd"
+        "id": null
       },
       "source": [
         "[![View on GitHub][github-badge]][github-basic] [![Open In Colab][colab-badge]][colab-basic] [![Open in Binder][binder-badge]][binder-basic]\n",
@@ -42,11 +40,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "99ag8qASZrEF"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "from typing import Callable, Optional, List, Tuple, Union\n",
         "\n",
@@ -58,11 +54,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "92nidAj7Z7Iy"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "class Inception(Layer):\n",
         "    filters_1x1: int\n",
@@ -134,13 +128,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "8cL7zNXKaLY0",
-        "outputId": "ff08829e-c091-4ae2-d0c2-f2e3e1778cea"
+        "id": null
       },
       "outputs": [
         {
@@ -292,9 +281,7 @@
   ],
   "metadata": {
     "colab": {
-      "collapsed_sections": [],
-      "name": "GoogLeNet implementation in Keras",
-      "provenance": []
+      "name": "GoogLeNet implementation in Keras"
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+++ b/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
@@ -2,11 +2,9 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "-52CicmjShjz"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -26,7 +24,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "BCsCeBGtx4Uo"
+        "id": null
       },
       "source": [
         "[![View on GitHub][github-badge]][github-keras-v1] [![Open In Colab][colab-badge]][colab-keras-v1] [![Open in Binder][binder-badge]][binder-keras-v1]\n",
@@ -42,11 +40,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "OfRXb7AXBNoB"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import tensorflow as tf\n",
@@ -58,11 +54,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "YHdoEW6wypv2"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "%pip install -q -U 'einops==0.4'\n",
         "import einops"
@@ -71,7 +65,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "PpVgtz3uuVJt"
+        "id": null
       },
       "source": [
         "We will start with a very simple approximation of the network described in the paper and evolve it over time to more closely match the paper.\n",
@@ -83,11 +77,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "rEBeAvrWBQCU"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Load the MNIST dataset.\n",
         "(x_train_raw, y_train_raw), (x_test_raw, y_test_raw) = keras.datasets.mnist.load_data()"
@@ -95,13 +87,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "NvI5jUrxoYDa",
-        "outputId": "b3331bfb-9819-423f-de78-f25a16fb3e80"
+        "id": null
       },
       "outputs": [
         {
@@ -127,14 +114,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "colab": {
-          "base_uri": "https://localhost:8080/",
           "height": 485
         },
-        "id": "5Z2r2CPLoz4G",
-        "outputId": "a50c6802-50ca-4512-eeba-b6274e449d7c"
+        "id": null
       },
       "outputs": [
         {
@@ -161,13 +145,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "E_yJqdvPqQmA",
-        "outputId": "b5f4e48d-6302-4e3c-d393-48b792358d80"
+        "id": null
       },
       "outputs": [
         {
@@ -186,7 +165,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "hNe4f-murG_2"
+        "id": null
       },
       "source": [
         "Since the $y$ values are the expected digits, but our network will output one-hot encoding of all 10 digits with probabilities of each value, we will need to convert it to a categorical value below."
@@ -194,13 +173,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "L9SC3sIaDv_i",
-        "outputId": "b983155f-ee98-4823-dd6a-53740f929d91"
+        "id": null
       },
       "outputs": [
         {
@@ -252,13 +226,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "WCCy-2SOrS33",
-        "outputId": "d5b361c8-0d2b-4873-ebc1-485300f8953f"
+        "id": null
       },
       "outputs": [
         {
@@ -287,13 +256,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "eptAFMyWBD8L",
-        "outputId": "d3d2fe1c-a375-4fae-d48b-caf74a4adff3"
+        "id": null
       },
       "outputs": [
         {
@@ -347,11 +311,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "bF7GGlO3EU7z"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Compile the model with optimizer and loss function.\n",
         "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
@@ -361,13 +323,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "UM_tm3UfBSt9",
-        "outputId": "2b9cae05-8a78-486a-fa3c-14630a20dd4b"
+        "id": null
       },
       "outputs": [
         {
@@ -422,8 +379,6 @@
               "<keras.callbacks.History at 0x7f78d5a74bd0>"
             ]
           },
-          "execution_count": null,
-          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -434,9 +389,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "fTLNTNHUnyEm"
+        "id": null
       },
       "outputs": [
         {
@@ -452,8 +406,6 @@
               "[0.04807252436876297, 0.9879000186920166]"
             ]
           },
-          "execution_count": null,
-          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -466,9 +418,7 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "collapsed_sections": [],
-      "name": "LeNet [v1]: basic implementation in Keras",
-      "provenance": []
+      "name": "LeNet [v1]: basic implementation in Keras"
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+++ b/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
@@ -2,11 +2,9 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "-52CicmjShjz"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -26,7 +24,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "-eOWhArxahUl"
+        "id": null
       },
       "source": [
         "[![View on GitHub][github-badge]][github-keras-v2] [![Open In Colab][colab-badge]][colab-keras-v2] [![Open in Binder][binder-badge]][binder-keras-v2]\n",
@@ -42,11 +40,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "OfRXb7AXBNoB"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "import numpy as np\n",
         "\n",
@@ -57,11 +53,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "LdXVAChTZu20"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Download and import custom Subsampling layer.\n",
         "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
@@ -70,11 +64,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "kuwdrBW1assu"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "%pip install -q -U 'einops==0.4'\n",
         "import einops"
@@ -82,11 +74,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "rEBeAvrWBQCU"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Load the MNIST dataset.\n",
         "(x_train_raw, y_train_raw), (x_test_raw, y_test_raw) = keras.datasets.mnist.load_data()"
@@ -94,13 +84,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "L9SC3sIaDv_i",
-        "outputId": "9c3a7e32-ceaa-48aa-8722-4144b824f511"
+        "id": null
       },
       "outputs": [
         {
@@ -126,13 +111,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "mhnNc_LSAoWh",
-        "outputId": "79c07b44-baf6-4062-99be-a667c6e80177"
+        "id": null
       },
       "outputs": [
         {
@@ -184,13 +164,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "6oCDY6OEDrOp",
-        "outputId": "5bd9c85d-2a63-4434-f605-03fceda823fd"
+        "id": null
       },
       "outputs": [
         {
@@ -219,11 +194,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "rSmV5tE911bM"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "def lenet_activation(a: float) -> float:\n",
         "    A = 1.7159\n",
@@ -233,13 +206,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "eptAFMyWBD8L",
-        "outputId": "a5db8a93-0352-4321-cd45-43116cb44879"
+        "id": null
       },
       "outputs": [
         {
@@ -292,11 +260,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "BenA0xmJA9_f"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Compile the model with optimizer and loss function.\n",
         "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
@@ -306,13 +272,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "UM_tm3UfBSt9",
-        "outputId": "e9a470d4-0de4-4499-91c9-cdfe056e8f4c"
+        "id": null
       },
       "outputs": [
         {
@@ -367,8 +328,6 @@
               "<keras.callbacks.History at 0x7f7d50577f10>"
             ]
           },
-          "execution_count": null,
-          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -379,13 +338,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "-oORwhVmEbV_",
-        "outputId": "0295e999-5d1c-44a8-d3ea-add07e3d0792"
+        "id": null
       },
       "outputs": [
         {
@@ -401,8 +355,6 @@
               "[0.05663033574819565, 0.9860000014305115]"
             ]
           },
-          "execution_count": null,
-          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -415,9 +367,7 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "collapsed_sections": [],
-      "name": "LeNet [v2]: custom Subsampling layer and activation function in Keras",
-      "provenance": []
+      "name": "LeNet [v2]: custom Subsampling layer and activation function in Keras"
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+++ b/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
@@ -2,11 +2,9 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "-52CicmjShjz"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -26,7 +24,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "N1mFS_HkbTNG"
+        "id": null
       },
       "source": [
         "[![View on GitHub][github-badge]][github-keras-v3] [![Open In Colab][colab-badge]][colab-keras-v3] [![Open in Binder][binder-badge]][binder-keras-v3]\n",
@@ -42,11 +40,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "OfRXb7AXBNoB"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "import numpy as np\n",
         "\n",
@@ -57,11 +53,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "R5nia9YHVMKc"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Download and import custom Subsampling layer.\n",
         "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
@@ -70,11 +64,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "IHNgGn3ZbQw4"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "%pip install -q -U 'einops==0.4'\n",
         "import einops"
@@ -82,13 +74,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "rEBeAvrWBQCU",
-        "outputId": "fa48284b-24ac-42cc-bc6e-d7a30abd278a"
+        "id": null
       },
       "outputs": [
         {
@@ -108,13 +95,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "L9SC3sIaDv_i",
-        "outputId": "8f68e841-cb01-4879-fd2d-182efb3dc49d"
+        "id": null
       },
       "outputs": [
         {
@@ -140,13 +122,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "mhnNc_LSAoWh",
-        "outputId": "847ad556-dc9a-4a91-a6fb-baa0eee6e69b"
+        "id": null
       },
       "outputs": [
         {
@@ -206,13 +183,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "6oCDY6OEDrOp",
-        "outputId": "63593869-1c79-4752-f2d1-5f561343b172"
+        "id": null
       },
       "outputs": [
         {
@@ -241,11 +213,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "rSmV5tE911bM"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "def lenet_activation(a: float) -> float:\n",
         "    A = 1.7159\n",
@@ -255,13 +225,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "eptAFMyWBD8L",
-        "outputId": "5f2cc55f-38a2-4766-a7f3-3bf874e680ab"
+        "id": null
       },
       "outputs": [
         {
@@ -314,11 +279,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "bF7GGlO3EU7z"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "def scheduler(epoch: int, lr: float) -> float:\n",
         "    if epoch < 2:\n",
@@ -341,11 +304,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "BenA0xmJA9_f"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Compile the model with optimizer and loss function.\n",
         "opt = keras.optimizers.Adam(learning_rate=0.0005)\n",
@@ -355,13 +316,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "UM_tm3UfBSt9",
-        "outputId": "72a70f0a-947a-4fde-e646-8906ecfb5d5e"
+        "id": null
       },
       "outputs": [
         {
@@ -418,13 +374,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "-oORwhVmEbV_",
-        "outputId": "2af11d0f-7160-45fd-8af1-fc95024353ec"
+        "id": null
       },
       "outputs": [
         {
@@ -440,8 +391,6 @@
               "[0.04284289851784706, 0.9864000082015991]"
             ]
           },
-          "execution_count": null,
-          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -454,9 +403,7 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "collapsed_sections": [],
-      "name": "LeNet [v3]: Subsamping, fixed scaling, and learning rate decay in Keras",
-      "provenance": []
+      "name": "LeNet [v3]: Subsamping, fixed scaling, and learning rate decay in Keras"
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/nbfmt.py
+++ b/nbfmt.py
@@ -27,9 +27,6 @@ import sys
 from typing import Dict, List
 
 
-EXECUTION_COUNT = 'execution_count'
-
-
 def processList(data: List):
     """Processes the passed-in list recursively, may modify it in-place."""
     for item in data:
@@ -41,15 +38,32 @@ def processList(data: List):
 
 def processDict(data: Dict):
     """Processes the passed-in dict recursively, may modify it in-place."""
-    # Reset execution counts for code cells.
-    if EXECUTION_COUNT in data:
-        data[EXECUTION_COUNT] = None
+    # Replace fields with default value `null` which aren't meaningful.
+    for field in ['id']:
+        if field in data:
+            data[field] = None
+
+    # Delete fields which don't need to be present in the notebook.
+    for field in ['base_uri', 'execution_count', 'outputId']:
+        if field in data:
+            del data[field]
 
     for key in data.keys():
         if isinstance(data[key], list):
             processList(data[key])
         elif isinstance(data[key], dict):
             processDict(data[key])
+
+    # Delete list and dict values if empty.
+    empty_fields = []
+    for field in data.keys():
+        value = data[field]
+        if ((isinstance(value, list) and len(value) == 0) or
+            (isinstance(value, dict) and len(value.keys()) == 0)):
+            empty_fields.append(field)
+
+    for field in empty_fields:
+        del data[field]
 
 
 # TODO(mbrukman): add flag `-w` to rewrite the file in-place, a la gofmt.

--- a/nbfmt_update.sh
+++ b/nbfmt_update.sh
@@ -16,15 +16,27 @@
 
 function clean_file() {
   local file="$1"
-  local temp="${file}.tmp"
+  local out="${file}.out"
+  local err="${file}.err"
 
   echo -n "Updating ${file} ... "
-  python "$(dirname $0)/nbfmt.py" "${file}" > "${temp}"
-  if diff "${file}" "${temp}" > /dev/null 2>&1; then
-    rm "${temp}"
+  if python "$(dirname $0)/nbfmt.py" "${file}" > "${out}" 2> "${err}"; then
+    # No issues; will continue with diffing `${out}` below.
+    rm "${err}"
+  else
+    echo "error:"
+    echo
+    cat "${err}"
+    echo
+    rm "${out}" "${err}"
+    return
+  fi
+
+  if diff "${file}" "${out}" > /dev/null 2>&1; then
+    rm "${out}"
     echo "no change."
   else
-    mv "${temp}" "${file}"
+    mv "${out}" "${file}"
     echo "done."
   fi
 }

--- a/vgg/Basic_VGG_in_Keras.ipynb
+++ b/vgg/Basic_VGG_in_Keras.ipynb
@@ -2,11 +2,9 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "Cd6PrIjsrx2d"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -26,7 +24,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "e22OwcveTAtP"
+        "id": null
       },
       "source": [
         "[![View on GitHub][github-badge]][github-basic] [![Open In Colab][colab-badge]][colab-basic] [![Open in Binder][binder-badge]][binder-basic]\n",
@@ -42,11 +40,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "wxCnecJqr2LP"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "from tensorflow import keras\n",
         "from keras import Input, Sequential\n",
@@ -55,11 +51,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "k5eXee6L5SBs"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "def Conv(filters: int, kernel_size: int, **kwargs) -> Conv2D:\n",
         "    \"\"\"Shorthand for defining the Conv2D layers for VGG family of models.\n",
@@ -86,11 +80,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "dv3LqkRc5Woo"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "# Available model types.\n",
         "MODEL_A = 'A'\n",
@@ -103,11 +95,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "0feiTuI5r4G0"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "def VGG(model: str) -> Sequential:\n",
         "    \"\"\"Defines a specific VGG model, given one of the valid model types.\"\"\"\n",
@@ -192,11 +182,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "id": "5T3pkvY_151d"
+        "id": null
       },
-      "outputs": [],
       "source": [
         "VGG_A = VGG(MODEL_A)\n",
         "VGG_A_LRN = VGG(MODEL_A_LRN)\n",
@@ -208,13 +196,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "LM2znmml0AZX",
-        "outputId": "5d6b58e8-de07-4309-984c-cf4aa16622ff"
+        "id": null
       },
       "outputs": [
         {
@@ -275,13 +258,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Ka4dmIKK0D3z",
-        "outputId": "d704762d-4eed-45fa-9080-0d03331906c1"
+        "id": null
       },
       "outputs": [
         {
@@ -342,13 +320,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "YkDUZ1Yr0EYe",
-        "outputId": "3ab0cc76-4c98-4be8-8130-1ae807ae68a8"
+        "id": null
       },
       "outputs": [
         {
@@ -413,13 +386,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "evyOFgiD0GVI",
-        "outputId": "41107897-9384-4920-ba04-26061295a61a"
+        "id": null
       },
       "outputs": [
         {
@@ -490,13 +458,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "RkgGL2lZ0GK4",
-        "outputId": "d7028b36-b5d0-44a5-c5b5-d3e741609820"
+        "id": null
       },
       "outputs": [
         {
@@ -567,13 +530,8 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "o2BKw_OM0Fvh",
-        "outputId": "206e2a85-7ac3-451b-c67e-c2a2356f529d"
+        "id": null
       },
       "outputs": [
         {
@@ -651,8 +609,7 @@
   ],
   "metadata": {
     "colab": {
-      "name": "Basic VGG network in Keras",
-      "provenance": []
+      "name": "Basic VGG network in Keras"
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION
* Remove fields `base_uri`, `execution_count`, and `outputId`
* Set the field `id` to `null` for simplicity
* Delete all empty lists and dicts

This makes it easier to avoid more noise in the diffs as we update notebooks over time with new features, refactorings, or simply cleanups.

Ensured that the notebooks are still openable by Colab; in particular, removing the `id` field from elements makes them non-loadable, so that field is critical, but its value can be set to `null` and Colab will assign a random value to it, so we can clear it to avoid extra diffs.