### PR TITLE
Restore fields required by `nbconvert` and GitHub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,9 @@ jobs:
 
     - name: Run nbconvert test
       run: make nbconvert-test
-      continue-on-error: true
 
     - name: Run notebook format test
-      run: make test
+      run: make nbfmt-test
 
     - name: Install tools for building SVG diagrams
       run: |

--- a/alexnet/AlexNet_for_CIFAR-10_in_Keras_with_tf_nn_LocalResponseNormalization.ipynb
+++ b/alexnet/AlexNet_for_CIFAR-10_in_Keras_with_tf_nn_LocalResponseNormalization.ipynb
@@ -2,9 +2,11 @@
   "cells": [
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -23,9 +25,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import tensorflow as tf\n",
@@ -37,9 +41,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/local_response_normalization.py\n",
         "\n",
@@ -48,6 +54,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -69,9 +76,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "num_classes = 10\n",
         "\n",
@@ -87,6 +96,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -152,9 +162,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Compile the model with optimizer and loss function.\n",
         "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
@@ -164,6 +176,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -220,6 +233,8 @@
               "<keras.callbacks.History at 0x7fb8c04226d0>"
             ]
           },
+          "execution_count": null,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -230,6 +245,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -247,6 +263,8 @@
               "[1.2246522903442383, 0.7002999782562256]"
             ]
           },
+          "execution_count": null,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],

--- a/alexnet/AlexNet_for_CIFAR-10_with_Pylearn2_Keras_LRN.ipynb
+++ b/alexnet/AlexNet_for_CIFAR-10_with_Pylearn2_Keras_LRN.ipynb
@@ -2,9 +2,11 @@
   "cells": [
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -23,9 +25,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import tensorflow as tf\n",
@@ -37,9 +41,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Download the Pylearn2/Keras implementation of LocalResponseNormalization.\n",
         "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/third_party/pylearn2/local_response_normalization.py\n",
@@ -49,6 +55,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -70,9 +77,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "num_classes = 10\n",
         "\n",
@@ -88,6 +97,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -151,9 +161,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Compile the model with optimizer and loss function.\n",
         "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
@@ -163,6 +175,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -219,6 +232,8 @@
               "<keras.callbacks.History at 0x7f4a7e7a5850>"
             ]
           },
+          "execution_count": null,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -229,6 +244,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -246,6 +262,8 @@
               "[1.3027948141098022, 0.6922000050544739]"
             ]
           },
+          "execution_count": null,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],

--- a/alexnet/Basic_AlexNet_in_Keras.ipynb
+++ b/alexnet/Basic_AlexNet_in_Keras.ipynb
@@ -2,9 +2,11 @@
   "cells": [
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -40,9 +42,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import tensorflow as tf\n",
@@ -54,9 +58,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/local_response_normalization.py\n",
         "\n",
@@ -65,6 +71,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },

--- a/datasets/cifar-10/CIFAR-10_-_Exploratory_Data_Analysis.ipynb
+++ b/datasets/cifar-10/CIFAR-10_-_Exploratory_Data_Analysis.ipynb
@@ -2,6 +2,11 @@
   "cells": [
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -20,6 +25,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": null
+      },
       "source": [
         "[![View on GitHub][github-badge]][github-eda] [![Open In Colab][colab-badge]][colab-eda] [![Open in Binder][binder-badge]][binder-eda]\n",
         "\n",
@@ -34,6 +42,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
       "source": [
         "from tensorflow import keras\n",
         "from matplotlib import pyplot as plt"
@@ -41,6 +54,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
       "source": [
         "# Load the CIFAR-10 dataset.\n",
         "(x_train_raw, y_train_raw), (x_test_raw, y_test_raw) = keras.datasets.cifar10.load_data();"
@@ -48,6 +66,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
       "source": [
         "# Examine the dataset shape.\n",
         "print(\"Raw data:\")\n",
@@ -59,6 +82,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
       "source": [
         "# Let's see what some of the training images and raw input data look like.\n",
         "fig = plt.figure(figsize=(8, 8))\n",
@@ -73,12 +101,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
       "source": [
         "print(\"Raw x train:\\n\", x_train_raw[0, :])"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
       "source": [
         "print(f\"X train raw stats: min={x_train_raw.min()}, max={x_train_raw.max()}\")\n",
         "print(f\"X test  raw stats: min={x_test_raw.min()}, max={x_test_raw.max()}\")"
@@ -86,6 +124,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
       "source": [
         "num_classes = 10\n",
         "\n",
@@ -101,12 +144,22 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
       "source": [
         "print(\"Processed x train:\\n\", x_train[0, :])"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
       "source": [
         "print(\"Raw y train:\", y_train_raw[0])\n",
         "print(\"Processed y train:\", y_train[0])"

--- a/googlenet/GoogLeNet_implementation_in_Keras.ipynb
+++ b/googlenet/GoogLeNet_implementation_in_Keras.ipynb
@@ -2,9 +2,11 @@
   "cells": [
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -40,9 +42,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "from typing import Callable, Optional, List, Tuple, Union\n",
         "\n",
@@ -54,9 +58,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "class Inception(Layer):\n",
         "    filters_1x1: int\n",
@@ -128,6 +134,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },

--- a/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+++ b/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
@@ -2,9 +2,11 @@
   "cells": [
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -40,9 +42,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "import tensorflow as tf\n",
@@ -54,9 +58,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "%pip install -q -U 'einops==0.4'\n",
         "import einops"
@@ -77,9 +83,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Load the MNIST dataset.\n",
         "(x_train_raw, y_train_raw), (x_test_raw, y_test_raw) = keras.datasets.mnist.load_data()"
@@ -87,6 +95,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -114,6 +123,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "colab": {
           "height": 485
@@ -145,6 +155,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -173,6 +184,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -226,6 +238,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -256,6 +269,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -311,9 +325,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Compile the model with optimizer and loss function.\n",
         "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
@@ -323,6 +339,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -379,6 +396,8 @@
               "<keras.callbacks.History at 0x7f78d5a74bd0>"
             ]
           },
+          "execution_count": null,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -389,6 +408,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -406,6 +426,8 @@
               "[0.04807252436876297, 0.9879000186920166]"
             ]
           },
+          "execution_count": null,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],

--- a/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+++ b/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
@@ -2,9 +2,11 @@
   "cells": [
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -40,9 +42,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "\n",
@@ -53,9 +57,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Download and import custom Subsampling layer.\n",
         "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
@@ -64,9 +70,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "%pip install -q -U 'einops==0.4'\n",
         "import einops"
@@ -74,9 +82,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Load the MNIST dataset.\n",
         "(x_train_raw, y_train_raw), (x_test_raw, y_test_raw) = keras.datasets.mnist.load_data()"
@@ -84,6 +94,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -111,6 +122,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -164,6 +176,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -194,9 +207,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "def lenet_activation(a: float) -> float:\n",
         "    A = 1.7159\n",
@@ -206,6 +221,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -260,9 +276,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Compile the model with optimizer and loss function.\n",
         "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
@@ -272,6 +290,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -328,6 +347,8 @@
               "<keras.callbacks.History at 0x7f7d50577f10>"
             ]
           },
+          "execution_count": null,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],
@@ -338,6 +359,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -355,6 +377,8 @@
               "[0.05663033574819565, 0.9860000014305115]"
             ]
           },
+          "execution_count": null,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],

--- a/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+++ b/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
@@ -2,9 +2,11 @@
   "cells": [
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -40,9 +42,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n",
         "\n",
@@ -53,9 +57,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Download and import custom Subsampling layer.\n",
         "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
@@ -64,9 +70,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "%pip install -q -U 'einops==0.4'\n",
         "import einops"
@@ -74,6 +82,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -95,6 +104,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -122,6 +132,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -183,6 +194,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -213,9 +225,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "def lenet_activation(a: float) -> float:\n",
         "    A = 1.7159\n",
@@ -225,6 +239,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -279,9 +294,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "def scheduler(epoch: int, lr: float) -> float:\n",
         "    if epoch < 2:\n",
@@ -304,9 +321,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Compile the model with optimizer and loss function.\n",
         "opt = keras.optimizers.Adam(learning_rate=0.0005)\n",
@@ -316,6 +335,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -374,6 +394,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -391,6 +412,8 @@
               "[0.04284289851784706, 0.9864000082015991]"
             ]
           },
+          "execution_count": null,
+          "metadata": {},
           "output_type": "execute_result"
         }
       ],

--- a/nbconvert_test.sh
+++ b/nbconvert_test.sh
@@ -21,16 +21,15 @@ function test_file() {
   local html="${file/%ipynb/html}"
   local err="${file}.err"
 
-  echo -n "::group::Converting ${file} ... "
   jupyter nbconvert --to html "${file}" 2> "${err}"
   if [ $? -eq 0 ]; then
-    echo "ok"
+    echo "Converting ${file} ... ok"
   else
     status=1
-    echo "failed"
+    echo "::group::Converting ${file} ... failed"
     cat "${err}"
+    echo "::endgroup::"
   fi
-  echo "::endgroup::"
   rm -f "${err}" "${html}"
 }
 

--- a/nbfmt.py
+++ b/nbfmt.py
@@ -38,13 +38,17 @@ def processList(data: List):
 
 def processDict(data: Dict):
     """Processes the passed-in dict recursively, may modify it in-place."""
-    # Replace fields with default value `null` which aren't meaningful.
-    for field in ['id']:
+    # Replace fields with default value `null` which aren't meaningful:
+    #
+    # * Colab doesn't load a notebook missing the `id` field.
+    # * GitHub and `nbconvert` don't load notebooks missing the
+    #   `execution_count` field.
+    for field in ('execution_count', 'id'):
         if field in data:
             data[field] = None
 
     # Delete fields which don't need to be present in the notebook.
-    for field in ['base_uri', 'execution_count', 'hash', 'outputId']:
+    for field in ('base_uri', 'hash', 'outputId'):
         if field in data:
             del data[field]
 
@@ -55,14 +59,20 @@ def processDict(data: Dict):
             processDict(data[key])
 
     # Delete list and dict values if empty.
-    empty_fields = []
+    #
+    # GitHub and `nbconvert` require the following fields even if empty:
+    # `metadata`, `outputs`.
+    required_even_if_empty = ['metadata', 'outputs']
+    empty_fields_to_delete = []
     for field in data.keys():
+        if field in required_even_if_empty:
+            continue
         value = data[field]
         if ((isinstance(value, list) and len(value) == 0) or
             (isinstance(value, dict) and len(value.keys()) == 0)):
-            empty_fields.append(field)
+            empty_fields_to_delete.append(field)
 
-    for field in empty_fields:
+    for field in empty_fields_to_delete:
         del data[field]
 
 

--- a/nbfmt_update.sh
+++ b/nbfmt_update.sh
@@ -41,6 +41,6 @@ function clean_file() {
   fi
 }
 
-for file in $(find . -name \*\.ipynb); do
+for file in $(find . -name \*\.ipynb | sort); do
   clean_file "${file}"
 done

--- a/vgg/Basic_VGG_in_Keras.ipynb
+++ b/vgg/Basic_VGG_in_Keras.ipynb
@@ -2,9 +2,11 @@
   "cells": [
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Copyright 2022 Google LLC\n",
         "#\n",
@@ -40,9 +42,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "from tensorflow import keras\n",
         "from keras import Input, Sequential\n",
@@ -51,9 +55,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "def Conv(filters: int, kernel_size: int, **kwargs) -> Conv2D:\n",
         "    \"\"\"Shorthand for defining the Conv2D layers for VGG family of models.\n",
@@ -80,9 +86,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "# Available model types.\n",
         "MODEL_A = 'A'\n",
@@ -95,9 +103,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "def VGG(model: str) -> Sequential:\n",
         "    \"\"\"Defines a specific VGG model, given one of the valid model types.\"\"\"\n",
@@ -182,9 +192,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
         "VGG_A = VGG(MODEL_A)\n",
         "VGG_A_LRN = VGG(MODEL_A_LRN)\n",
@@ -196,6 +208,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -258,6 +271,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -320,6 +334,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -386,6 +401,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -458,6 +474,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
@@ -530,6 +547,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },


### PR DESCRIPTION
This is necessary for the `nbconvert` tool and possibly similarly required by the GitHub HTML preview functionality for all notebooks.

Also restored the `id` field in the datasets exploration notebook which is required for Colab to be able to load it.

Updated the script to avoid removing the `outputs` field.