### PR TITLE
Add caching support for Python `pip` packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,18 +22,26 @@ on:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+        python: ['3.10']
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
 
     - name: Checkout the repo
       uses: actions/checkout@v3
 
-    - name: Install Jupyter and nbconvert
-      run: |
-        pip install jupyterlab
-        pip install nbconvert
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+        cache: 'pip'
+
+    - name: Install Python deps
+      run: pip install -r requirements.txt
 
     - name: Run nbconvert test
       run: make nbconvert-test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+jupyterlab ~= 3.5.0
+nbconvert ~= 7.2.5


### PR DESCRIPTION
Installing the `jupyterlab` and `nbconvert` packages that we need for testing currently takes 25s of our test run, which takes about a minute, so it's a significant fraction.  Caching should ideally remove the cost of this step, and bring our run to below a minute.