### PR TITLE
Add badges and library link to MNIST EDA notebook

### DIFF
--- a/datasets/mnist/MNIST_-_Exploratory_Data_Analysis.ipynb
+++ b/datasets/mnist/MNIST_-_Exploratory_Data_Analysis.ipynb
@@ -24,6 +24,23 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": null
+      },
+      "source": [
+        "[![View on GitHub][github-badge]][github-eda] [![Open In Colab][colab-badge]][colab-eda] [![Open in Binder][binder-badge]][binder-eda]\n",
+        "\n",
+        "[github-badge]: https://img.shields.io/badge/View-on%20GitHub-blue?logo=GitHub\n",
+        "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
+        "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
+        "\n",
+        "[github-eda]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/datasets/mnist/MNIST_-_Exploratory_Data_Analysis.ipynb\n",
+        "[colab-eda]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/datasets/mnist/MNIST_-_Exploratory_Data_Analysis.ipynb\n",
+        "[binder-eda]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=datasets/mnist/MNIST_-_Exploratory_Data_Analysis.ipynb"
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -329,6 +346,25 @@
         "\n",
         "print('\\nY (train) sample values after preprocessing:')\n",
         "print(y_train[0:4])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": null
+      },
+      "source": [
+        "## Using the library to simplify input and label transformations\n",
+        "\n",
+        "This directory provides [`mnist.py`][mnist-github] library which includes the\n",
+        "above transformations for scaling the input and converting the labels to a\n",
+        "categorical (one-hot) representation from the default numeric values, so you\n",
+        "can use it to simplify the data setup for training and testing MNIST models.\n",
+        "\n",
+        "You can see examples of how the library can be used in the [LeNet notebooks][lenet].\n",
+        "\n",
+        "[mnist-github]: https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/mnist/mnist.py\n",
+        "[lenet]: https://github.com/mbrukman/reimplementing-ml-papers/tree/main/lenet"
       ]
     }
   ],


### PR DESCRIPTION
* add badges to open notebook on GitHub, Colab, and Binder
* add link to the `mnist.py` library for common data and label transforms