### PR TITLE
LeNet: add activation after MaxPooling2D layer

### DIFF
--- a/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+++ b/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
@@ -52,7 +52,7 @@
         "import tensorflow as tf\n",
         "from tensorflow import keras\n",
         "from keras import Input, Sequential\n",
-        "from keras.layers import AveragePooling2D, MaxPooling2D, Conv2D, Dense, Flatten\n",
+        "from keras.layers import Activation, AveragePooling2D, MaxPooling2D, Conv2D, Dense, Flatten\n",
         "from matplotlib import pyplot as plt"
       ]
     },
@@ -133,17 +133,22 @@
         }
       ],
       "source": [
+        "tanh = keras.activations.tanh\n",
+        "softmax = keras.activations.softmax\n",
+        "\n",
         "# Define the model architecture.\n",
         "model = Sequential([\n",
         "    Input(shape=(28, 28, 1)),\n",
-        "    Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation='tanh', name='C1'),\n",
+        "    Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=tanh, name='C1'),\n",
         "    MaxPooling2D(pool_size=(2, 2), strides=(2, 2), name='S2'),\n",
-        "    Conv2D(filters=16, kernel_size=(5, 5), activation='tanh', name='C3'),\n",
+        "    Activation(tanh, name='S2_act'),\n",
+        "    Conv2D(filters=16, kernel_size=(5, 5), activation=tanh, name='C3'),\n",
         "    MaxPooling2D(pool_size=(2, 2), strides=(2, 2), name='S4'),\n",
+        "    Activation(tanh, name='S4_act'),\n",
         "    Flatten(),\n",
-        "    Dense(120, activation='tanh', name='C5'),\n",
-        "    Dense(84, activation='tanh', name='F6'),\n",
-        "    Dense(10, activation='softmax', name='Output'),\n",
+        "    Dense(120, activation=tanh, name='C5'),\n",
+        "    Dense(84, activation=tanh, name='F6'),\n",
+        "    Dense(10, activation=softmax, name='Output'),\n",
         "], name='LeNet-5')\n",
         "\n",
         "model.summary()"

--- a/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+++ b/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
@@ -98,20 +98,6 @@
       "metadata": {
         "id": null
       },
-      "outputs": [],
-      "source": [
-        "def lenet_activation(a: float) -> float:\n",
-        "    A = 1.7159\n",
-        "    S = 2. / 3\n",
-        "    return A * keras.activations.tanh(S * a)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
       "outputs": [
         {
           "name": "stdout",
@@ -146,16 +132,24 @@
         }
       ],
       "source": [
+        "def scaled_tanh(a: float) -> float:\n",
+        "    A = 1.7159\n",
+        "    S = 2. / 3\n",
+        "    return A * keras.activations.tanh(S * a)\n",
+        "\n",
+        "softmax = keras.activations.softmax\n",
+        "\n",
+        "# Define the model architecture.\n",
         "model = Sequential([\n",
         "    Input(shape=(28, 28, 1)),\n",
-        "    Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=lenet_activation, name='C1'),\n",
-        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=lenet_activation, name='S2'),\n",
-        "    Conv2D(filters=16, kernel_size=(5, 5), activation=lenet_activation, name='C3'),\n",
-        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=lenet_activation, name='S4'),\n",
+        "    Conv2D(filters=6, kernel_size=(5, 5), activation=scaled_tanh, padding='same', name='C1'),\n",
+        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=scaled_tanh, name='S2'),\n",
+        "    Conv2D(filters=16, kernel_size=(5, 5), activation=scaled_tanh, name='C3'),\n",
+        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=scaled_tanh, name='S4'),\n",
         "    Flatten(),\n",
-        "    Dense(120, activation=lenet_activation, name='C5'),\n",
-        "    Dense(84, activation=lenet_activation, name='F6'),\n",
-        "    Dense(10, activation='softmax', name='Output'),\n",
+        "    Dense(120, activation=scaled_tanh, name='C5'),\n",
+        "    Dense(84, activation=scaled_tanh, name='F6'),\n",
+        "    Dense(10, activation=softmax, name='Output'),\n",
         "], name='LeNet-5')\n",
         "\n",
         "model.summary()"

--- a/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+++ b/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
@@ -98,20 +98,6 @@
       "metadata": {
         "id": null
       },
-      "outputs": [],
-      "source": [
-        "def lenet_activation(a: float) -> float:\n",
-        "    A = 1.7159\n",
-        "    S = 2. / 3\n",
-        "    return A * keras.activations.tanh(S * a)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
       "outputs": [
         {
           "name": "stdout",
@@ -146,16 +132,24 @@
         }
       ],
       "source": [
+        "def scaled_tanh(a: float) -> float:\n",
+        "    A = 1.7159\n",
+        "    S = 2. / 3\n",
+        "    return A * keras.activations.tanh(S * a)\n",
+        "\n",
+        "softmax = keras.activations.softmax\n",
+        "\n",
+        "# Define the model architecture.\n",
         "model = Sequential([\n",
         "    Input(shape=(28, 28, 1)),\n",
-        "    Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=lenet_activation, name='C1'),\n",
-        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=lenet_activation, name='S2'),\n",
-        "    Conv2D(filters=16, kernel_size=(5, 5), activation=lenet_activation, name='C3'),\n",
-        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=lenet_activation, name='S4'),\n",
+        "    Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=scaled_tanh, name='C1'),\n",
+        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=scaled_tanh, name='S2'),\n",
+        "    Conv2D(filters=16, kernel_size=(5, 5), activation=scaled_tanh, name='C3'),\n",
+        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=scaled_tanh, name='S4'),\n",
         "    Flatten(),\n",
-        "    Dense(120, activation=lenet_activation, name='C5'),\n",
-        "    Dense(84, activation=lenet_activation, name='F6'),\n",
-        "    Dense(10, activation='softmax', name='Output'),\n",
+        "    Dense(120, activation=scaled_tanh, name='C5'),\n",
+        "    Dense(84, activation=scaled_tanh, name='F6'),\n",
+        "    Dense(10, activation=softmax, name='Output'),\n",
         "], name='LeNet-5')\n",
         "\n",
         "model.summary()"


### PR DESCRIPTION
This layer does not accept an `activation` parameter as Conv2D and our custom Subsampling layer do, so it needs to be added explicitly via an Activation layer.

Also switch from using string shortcut names for activations to symbolic names for consistency, and rename `lenet_activation` to `scaled_tanh` as it's more descriptive.

Combine the activation functions definitions with the model architecture cell for improved readability.