### PR TITLE
LeNet: move MNIST usage closer to model training

### DIFF
--- a/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+++ b/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
@@ -62,30 +62,6 @@
         "id": null
       },
       "source": [
-        "For details on the MNIST dataset including a data exploration, see [MNIST directory in my repo](https://github.com/mbrukman/reimplementing-ml-papers/tree/main/datasets/mnist).\n",
-        "\n",
-        "Here, we will import a shared library to process the MNIST dataset into the format that we need to use below for model training and testing."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
-        "# Download and import our library for processing MNIST dataset.\n",
-        "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/mnist/mnist.py\n",
-        "from mnist import MNIST"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": null
-      },
-      "source": [
         "We will start with a very simple approximation of the network described in the paper and evolve it over time to more closely match the paper.\n",
         "\n",
         "For one, there isn't a built-in Keras layer that matches the subsampling layer in the paper: neither `AveragePooling2D` nor `MaxPooling2D` have any trainable parameters, but the subsampling layer described in the paper does, so this is already one difference.\n",
@@ -112,9 +88,13 @@
             "                                                                 \n",
             " S2 (MaxPooling2D)           (None, 14, 14, 6)         0         \n",
             "                                                                 \n",
+            " S2_act (Activation)         (None, 14, 14, 6)         0         \n",
+            "                                                                 \n",
             " C3 (Conv2D)                 (None, 10, 10, 16)        2416      \n",
             "                                                                 \n",
             " S4 (MaxPooling2D)           (None, 5, 5, 16)          0         \n",
+            "                                                                 \n",
+            " S4_act (Activation)         (None, 5, 5, 16)          0         \n",
             "                                                                 \n",
             " flatten (Flatten)           (None, 400)               0         \n",
             "                                                                 \n",
@@ -169,6 +149,33 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": null
+      },
+      "source": [
+        "For details on the MNIST dataset including a data exploration, see [MNIST directory in my repo](https://github.com/mbrukman/reimplementing-ml-papers/tree/main/datasets/mnist).\n",
+        "\n",
+        "Here, we will import a shared library to process the MNIST dataset into the format that we need to use below for model training and testing."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
+      "source": [
+        "%%bash\n",
+        "\n",
+        "# Download our library for processing MNIST dataset.\n",
+        "if ! [ -f \"mnist.py\" ]; then\n",
+        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/mnist/mnist.py\n",
+        "fi"
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -177,7 +184,12 @@
       "outputs": [],
       "source": [
         "%%capture --no-stderr\n",
-        "mnist = MNIST()"
+        "\n",
+        "import mnist\n",
+        "\n",
+        "# This will download the MNIST dataset via the Keras library which outputs data\n",
+        "# to stdout, so we silence it above to avoid extraneous output.\n",
+        "mnist_data = mnist.MNIST()"
       ]
     },
     {
@@ -251,7 +263,9 @@
         "# labels y to a categorical (one-hot) encoding from the default numeric values.\n",
         "#\n",
         "# For consistency, we use the same transformations for the test dataset below.\n",
-        "model.fit(mnist.x_train_scale_0_1(), mnist.y_train_categorical(), epochs=20)"
+        "model.fit(mnist_data.x_train_scale_0_1(),\n",
+        "          mnist_data.y_train_categorical(),\n",
+        "          epochs=20)"
       ]
     },
     {
@@ -283,7 +297,7 @@
         "# Evaluate the model.\n",
         "#\n",
         "# Note that we use the same input range scaling and label encoding as above.\n",
-        "model.evaluate(mnist.x_test_scale_0_1(), mnist.y_test_categorical())"
+        "model.evaluate(mnist_data.x_test_scale_0_1(), mnist_data.y_test_categorical())"
       ]
     }
   ],

--- a/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+++ b/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
@@ -69,30 +69,6 @@
       ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": null
-      },
-      "source": [
-        "For details on the MNIST dataset including a data exploration, see [MNIST directory in my repo](https://github.com/mbrukman/reimplementing-ml-papers/tree/main/datasets/mnist).\n",
-        "\n",
-        "Here, we will import a shared library to process the MNIST dataset into the format that we need to use below for model training and testing."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
-        "# Download and import our library for processing MNIST dataset.\n",
-        "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/mnist/mnist.py\n",
-        "from mnist import MNIST"
-      ]
-    },
-    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -170,6 +146,33 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": null
+      },
+      "source": [
+        "For details on the MNIST dataset including a data exploration, see [MNIST directory in my repo](https://github.com/mbrukman/reimplementing-ml-papers/tree/main/datasets/mnist).\n",
+        "\n",
+        "Here, we will import a shared library to process the MNIST dataset into the format that we need to use below for model training and testing."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
+      "source": [
+        "%%bash\n",
+        "\n",
+        "# Download our library for processing MNIST dataset.\n",
+        "if ! [ -f \"mnist.py\" ]; then\n",
+        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/mnist/mnist.py\n",
+        "fi"
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -178,7 +181,12 @@
       "outputs": [],
       "source": [
         "%%capture --no-stderr\n",
-        "mnist = MNIST()"
+        "\n",
+        "import mnist\n",
+        "\n",
+        "# This will download the MNIST dataset via the Keras library which outputs data\n",
+        "# to stdout, so we silence it above to avoid extraneous output.\n",
+        "mnist_data = mnist.MNIST()"
       ]
     },
     {
@@ -193,51 +201,51 @@
           "output_type": "stream",
           "text": [
             "Epoch 1/20\n",
-            "1875/1875 [==============================] - 17s 4ms/step - loss: 0.2829 - accuracy: 0.9114\n",
+            "1875/1875 [==============================] - 16s 4ms/step - loss: 0.2747 - accuracy: 0.9146\n",
             "Epoch 2/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0939 - accuracy: 0.9718\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0920 - accuracy: 0.9722\n",
             "Epoch 3/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0614 - accuracy: 0.9808\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0606 - accuracy: 0.9815\n",
             "Epoch 4/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0471 - accuracy: 0.9856\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0451 - accuracy: 0.9860\n",
             "Epoch 5/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0395 - accuracy: 0.9870\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0352 - accuracy: 0.9890\n",
             "Epoch 6/20\n",
-            "1875/1875 [==============================] - 8s 4ms/step - loss: 0.0317 - accuracy: 0.9899\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0309 - accuracy: 0.9903\n",
             "Epoch 7/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0256 - accuracy: 0.9912\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0245 - accuracy: 0.9917\n",
             "Epoch 8/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0222 - accuracy: 0.9927\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0196 - accuracy: 0.9934\n",
             "Epoch 9/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0199 - accuracy: 0.9934\n",
+            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0193 - accuracy: 0.9932\n",
             "Epoch 10/20\n",
-            "1875/1875 [==============================] - 8s 4ms/step - loss: 0.0171 - accuracy: 0.9942\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0173 - accuracy: 0.9942\n",
             "Epoch 11/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0155 - accuracy: 0.9948\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0134 - accuracy: 0.9955\n",
             "Epoch 12/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0134 - accuracy: 0.9958\n",
+            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0136 - accuracy: 0.9954\n",
             "Epoch 13/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0134 - accuracy: 0.9956\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0121 - accuracy: 0.9960\n",
             "Epoch 14/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0133 - accuracy: 0.9955\n",
+            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0112 - accuracy: 0.9961\n",
             "Epoch 15/20\n",
-            "1875/1875 [==============================] - 8s 4ms/step - loss: 0.0115 - accuracy: 0.9961\n",
+            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0092 - accuracy: 0.9967\n",
             "Epoch 16/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0111 - accuracy: 0.9963\n",
+            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0110 - accuracy: 0.9966\n",
             "Epoch 17/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0091 - accuracy: 0.9967\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0106 - accuracy: 0.9964\n",
             "Epoch 18/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0097 - accuracy: 0.9967\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0073 - accuracy: 0.9978\n",
             "Epoch 19/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0085 - accuracy: 0.9970\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0083 - accuracy: 0.9972\n",
             "Epoch 20/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0104 - accuracy: 0.9964\n"
+            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0101 - accuracy: 0.9967\n"
           ]
         },
         {
           "data": {
             "text/plain": [
-              "<keras.callbacks.History at 0x7f9810142c70>"
+              "<keras.callbacks.History at 0x7fcbd001ee80>"
             ]
           },
           "execution_count": null,
@@ -252,7 +260,9 @@
         "# labels y to a categorical (one-hot) encoding from the default numeric values.\n",
         "#\n",
         "# For consistency, we use the same transformations for the test dataset below.\n",
-        "model.fit(mnist.x_train_scale_0_1(), mnist.y_train_categorical(), epochs=20)"
+        "model.fit(mnist_data.x_train_scale_0_1(),\n",
+        "          mnist_data.y_train_categorical(),\n",
+        "          epochs=20)"
       ]
     },
     {
@@ -266,13 +276,13 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "313/313 [==============================] - 1s 3ms/step - loss: 0.0722 - accuracy: 0.9838\n"
+            "313/313 [==============================] - 1s 3ms/step - loss: 0.0683 - accuracy: 0.9853\n"
           ]
         },
         {
           "data": {
             "text/plain": [
-              "[0.0722367987036705, 0.9837999939918518]"
+              "[0.06825553625822067, 0.9853000044822693]"
             ]
           },
           "execution_count": null,
@@ -284,7 +294,7 @@
         "# Evaluate the model.\n",
         "#\n",
         "# Note that we use the same input range scaling and label encoding as above.\n",
-        "model.evaluate(mnist.x_test_scale_0_1(), mnist.y_test_categorical())"
+        "model.evaluate(mnist_data.x_test_scale_0_1(), mnist_data.y_test_categorical())"
       ]
     }
   ],

--- a/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+++ b/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
@@ -69,30 +69,6 @@
       ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": null
-      },
-      "source": [
-        "For details on the MNIST dataset including a data exploration, see [MNIST directory in my repo](https://github.com/mbrukman/reimplementing-ml-papers/tree/main/datasets/mnist).\n",
-        "\n",
-        "Here, we will import a shared library to process the MNIST dataset into the format that we need to use below for model training and testing."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
-        "# Download and import our library for processing MNIST dataset.\n",
-        "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/mnist/mnist.py\n",
-        "from mnist import MNIST"
-      ]
-    },
-    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -197,6 +173,33 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": null
+      },
+      "source": [
+        "For details on the MNIST dataset including a data exploration, see [MNIST directory in my repo](https://github.com/mbrukman/reimplementing-ml-papers/tree/main/datasets/mnist).\n",
+        "\n",
+        "Here, we will import a shared library to process the MNIST dataset into the format that we need to use below for model training and testing."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
+      "source": [
+        "%%bash\n",
+        "\n",
+        "# Download our library for processing MNIST dataset.\n",
+        "if ! [ -f \"mnist.py\" ]; then\n",
+        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/mnist/mnist.py\n",
+        "fi"
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -205,7 +208,12 @@
       "outputs": [],
       "source": [
         "%%capture --no-stderr\n",
-        "mnist = MNIST()\n",
+        "\n",
+        "import mnist\n",
+        "\n",
+        "# This will download the MNIST dataset via the Keras library which outputs data\n",
+        "# to stdout, so we silence it above to avoid extraneous output.\n",
+        "mnist_data = mnist.MNIST()\n",
         "mnist_input_range = (-0.1, 1.175)"
       ]
     },
@@ -271,8 +279,8 @@
         "# default numeric values.\n",
         "#\n",
         "# For consistency, we use the same transformations for the test dataset below.\n",
-        "history = model.fit(mnist.x_train_scale_custom(mnist_input_range),\n",
-        "                    mnist.y_train_categorical(),\n",
+        "history = model.fit(mnist_data.x_train_scale_custom(mnist_input_range),\n",
+        "                    mnist_data.y_train_categorical(),\n",
         "                    epochs=20,\n",
         "                    callbacks=[lr_callback])"
       ]
@@ -306,8 +314,8 @@
         "# Evaluate the model\n",
         "#\n",
         "# Note that we use the same input range scaling and label encoding as above.\n",
-        "model.evaluate(mnist.x_test_scale_custom(mnist_input_range),\n",
-        "               mnist.y_test_categorical())"
+        "model.evaluate(mnist_data.x_test_scale_custom(mnist_input_range),\n",
+        "               mnist_data.y_test_categorical())"
       ]
     }
   ],


### PR DESCRIPTION
Move the download, import, and usage of the MNIST library closer to where it's used, so that it's not disconnected into two parts: downloading and import at the top, and usage at the bottom of the notebook. This way it's more self-contained and easier to read.