### PR TITLE
LeNet: reuse local Subsampling file if present

### DIFF
--- a/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+++ b/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
@@ -63,9 +63,12 @@
       },
       "outputs": [],
       "source": [
-        "# Download and import custom Subsampling layer.\n",
-        "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
-        "from subsampling import Subsampling"
+        "%%bash\n",
+        "\n",
+        "# Download our custom Subsampling layer.\n",
+        "if ! [ -f \"subsampling.py\" ]; then\n",
+        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
+        "fi"
       ]
     },
     {
@@ -108,6 +111,8 @@
         }
       ],
       "source": [
+        "from subsampling import Subsampling\n",
+        "\n",
         "def scaled_tanh(a: float) -> float:\n",
         "    A = 1.7159\n",
         "    S = 2. / 3\n",

--- a/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+++ b/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
@@ -63,9 +63,12 @@
       },
       "outputs": [],
       "source": [
-        "# Download and import custom Subsampling layer.\n",
-        "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
-        "from subsampling import Subsampling"
+        "%%bash\n",
+        "\n",
+        "# Download our custom Subsampling layer.\n",
+        "if ! [ -f \"subsampling.py\" ]; then\n",
+        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
+        "fi"
       ]
     },
     {
@@ -108,6 +111,8 @@
         }
       ],
       "source": [
+        "from subsampling import Subsampling\n",
+        "\n",
         "def scaled_tanh(a: float) -> float:\n",
         "    A = 1.7159\n",
         "    S = 2. / 3\n",


### PR DESCRIPTION
The `subsampling.py` already exists in the current directory, so if running this notebook locally, just reuse it instead of fetching it from GitHub. Also, if running in Colab, this ensures we only fetch it the first time, and continue to reuse it for the duration of the notebook session, so it it updates in the meantime, it does not change the local environment (and saves running time).