### PR TITLE
LeNet: Fix activation function used in v1

### DIFF
--- a/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+++ b/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
@@ -63,7 +63,7 @@
         "\n",
         "For one, there isn't a built-in Keras layer that matches the subsampling layer in the paper: neither `AveragePooling2D` nor `MaxPooling2D` have any trainable parameters, but the subsampling layer described in the paper does, so this is already one difference.\n",
         "\n",
-        "The activation function is a more complex function than the ReLU we're using here, but it's a reasonable approximation, and even with these changes, we get quite a good accuracy on both training and test sets."
+        "The activation function is a more complex function than the `tanh` we're using here, but it's a reasonable approximation, and even with these changes, we get quite a good accuracy on both training and test sets."
       ]
     },
     {


### PR DESCRIPTION
We're using `tanh` here, not `ReLU`, to be closer to the paper's own (scaled tanh), so update the name to match the implementation.

Previously, we used the ReLU activation function here, but replaced it with tanh, and didn't update the description when we did.