### PR TITLE
Add overridable paths to scripts in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,24 +17,26 @@ ifeq ($(VERBOSE),1)
 	VERB =
 endif
 
+SRC_DIR ?= .
+
 .PHONY: test clean
 
 test: nbfmt-test
 
-nbfmt-test: run_nbfmt_test.sh Makefile
+nbfmt-test:
 	$(VERB) echo "Notebook format tests"
 	$(VERB) echo
-	$(VERB) ./$<
+	$(VERB) $(SRC_DIR)/run_nbfmt_test.sh
 
 update: nbfmt-update
 
-nbfmt-update: nbfmt_update.sh Makefile
-	$(VERB) ./$<
+nbfmt-update:
+	$(VERB) $(SRC_DIR)/nbfmt_update.sh
 
-nbconvert-test: nbconvert_test.sh Makefile
+nbconvert-test:
 	$(VERB) echo "Notebook conversion tests"
 	$(VERB) echo
-	$(VERB) ./$<
+	$(VERB) $(SRC_DIR)/nbconvert_test.sh
 
 datasets-test:
 	$(VERB) make -C datasets test


### PR DESCRIPTION
We'd like to reuse the notebook formatting and testing scripts in another repo, where these scripts will be in a `third_party` subdirectory and the scripts will be referenced from there, where they won't be in `./` relative to the root of the repo.

The ability to override the path to the scripts will make it possible to reuse these scripts elsewhere without any local modifications.