### PR TITLE
Use absolute links to GitHub notebooks

### DIFF
--- a/alexnet/Basic_AlexNet_in_Keras.ipynb
+++ b/alexnet/Basic_AlexNet_in_Keras.ipynb
@@ -35,7 +35,7 @@
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
-        "[github-basic]: Basic_AlexNet_in_Keras.ipynb\n",
+        "[github-basic]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/alexnet/Basic_AlexNet_in_Keras.ipynb\n",
         "[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/alexnet/Basic_AlexNet_in_Keras.ipynb\n",
         "[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=alexnet/Basic_AlexNet_in_Keras.ipynb"
       ]

--- a/googlenet/GoogLeNet_implementation_in_Keras.ipynb
+++ b/googlenet/GoogLeNet_implementation_in_Keras.ipynb
@@ -35,7 +35,7 @@
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
-        "[github-basic]: GoogLeNet_implementation_in_Keras.ipynb\n",
+        "[github-basic]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/googlenet/GoogLeNet_implementation_in_Keras.ipynb\n",
         "[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/googlenet/GoogLeNet_implementation_in_Keras.ipynb\n",
         "[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=googlenet/GoogLeNet_implementation_in_Keras.ipynb"
       ]

--- a/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+++ b/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
@@ -35,7 +35,7 @@
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
-        "[github-keras-v1]: LeNet_v1_basic_impl_in_Keras.ipynb\n",
+        "[github-keras-v1]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v1_basic_impl_in_Keras.ipynb\n",
         "[colab-keras-v1]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v1_basic_impl_in_Keras.ipynb\n",
         "[binder-keras-v1]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v1_basic_impl_in_Keras.ipynb"
       ]

--- a/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+++ b/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
@@ -35,7 +35,7 @@
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
-        "[github-keras-v2]: LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb\n",
+        "[github-keras-v2]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb\n",
         "[colab-keras-v2]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb\n",
         "[binder-keras-v2]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb"
       ]

--- a/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+++ b/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
@@ -35,7 +35,7 @@
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
-        "[github-keras-v3]: LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb\n",
+        "[github-keras-v3]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb\n",
         "[colab-keras-v3]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb\n",
         "[binder-keras-v3]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb"
       ]

--- a/vgg/Basic_VGG_in_Keras.ipynb
+++ b/vgg/Basic_VGG_in_Keras.ipynb
@@ -35,7 +35,7 @@
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
-        "[github-basic]: Basic_VGG_in_Keras.ipynb\n",
+        "[github-basic]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/vgg/Basic_VGG_in_Keras.ipynb\n",
         "[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/vgg/Basic_VGG_in_Keras.ipynb\n",
         "[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=vgg/Basic_VGG_in_Keras.ipynb"
       ]


### PR DESCRIPTION
This will make it possible to open the GitHub notebook from other environments, such as Colab or Binder. The current relative URLs used in some places would only work when opening it on GitHub or locally, when it is not necessary.