### PR TITLE
Update AlexNet, VGG, and GoogLeNet as WIP

### DIFF
--- a/alexnet/README.md
+++ b/alexnet/README.md
@@ -19,9 +19,7 @@ with the ImageNet dataset.
 
 Implementation notes for ImageNet v1:
 
-1. We haven't yet trained or tested this network, as we don't yet have access to
-   the ImageNet dataset which requires registration & approval to be able to
-   download it.
+1. We haven't yet trained or tested this network (work in progress).
 
 ## References
 

--- a/googlenet/README.md
+++ b/googlenet/README.md
@@ -18,9 +18,7 @@ Available implementations:
 
 Implementation notes for v1:
 
-1. We haven't yet trained or tested this network, as we don't yet have access to
-   the ImageNet dataset which requires registration & approval to be able to
-   download it.
+1. We haven't yet trained or tested this network (work in progress).
 
 Our implementation is based on the following paper:
 

--- a/vgg/README.md
+++ b/vgg/README.md
@@ -12,9 +12,7 @@ Available implementations:
 
 Implementation notes for v1:
 
-1. We haven't yet trained or tested this network, as we don't yet have access to
-   the ImageNet dataset which requires registration & approval to be able to
-   download it.
+1. We haven't yet trained or tested this network (work in progress).
 
 Our implementation is based on the following paper:
 


### PR DESCRIPTION
We now have access to ImageNet (via a Kaggle competition), so the training of these networks is now in progress. This is just a docs update, so [skip ci].