### PR TITLE
LeNet: add historical implementation notes

### DIFF
--- a/lenet/README.md
+++ b/lenet/README.md
@@ -4,6 +4,10 @@ This directory aims to implement the LeNet architecture for a Convolutional
 Neural Network (CNN) used for character recognition, trained and tested with the
 [MNIST dataset](../datasets/mnist).
 
+See [implementation notes](notes.md) for historical implementation notes,
+explanation of the various implementation versions, and additional details, such
+as an extension of the custom Subsampling layer.
+
 Available implementations:
 
 |     | Description    | Input<br/>pixel<br/>range | Pooling<br/>layer | Activation | Learning<br/>rate | Library | Notebook |

--- a/lenet/activations.py
+++ b/lenet/activations.py
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from tensorflow import keras
+
+
+def scaled_tanh(a: tf.Tensor) -> tf.Tensor:
+    A = 1.7159
+    S = 2. / 3
+    return A * keras.activations.tanh(S * a)

--- a/lenet/lenet.py
+++ b/lenet/lenet.py
@@ -1,0 +1,37 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from tensorflow import keras
+from keras import Input, Sequential
+from keras.layers import Activation, AveragePooling2D, Conv2D, Dense, Flatten, Layer, MaxPooling2D
+
+from typing import Callable, Type
+
+
+def LeNet(subsampling: Type[keras.layers.Layer] = AveragePooling2D,
+          activation: Callable[[tf.Tensor], tf.Tensor] = keras.activations.tanh) -> Sequential:
+    return Sequential([
+        Input(shape=(28, 28, 1)),
+        Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=activation, name='C1'),
+        subsampling(pool_size=(2, 2), strides=(2, 2), name='S2'),
+        Activation(activation, name='S2_act'),
+        Conv2D(filters=16, kernel_size=(5, 5), activation=activation, name='C3'),
+        subsampling(pool_size=(2, 2), strides=(2, 2), name='S4'),
+        Activation(activation, name='S4_act'),
+        Conv2D(filters=120, kernel_size=(5, 5), activation=activation, name='C5'),
+        Flatten(name='Flatten'),
+        Dense(84, activation=activation, name='F6'),
+        Dense(10, activation=keras.activations.softmax, name='Output'),
+    ], name='LeNet-5')

--- a/lenet/notes.md
+++ b/lenet/notes.md
@@ -1,0 +1,136 @@
+# LeNet implementation notes
+
+Most LeNet implementations use the `AveragePooling2D` or `MaxPooling2D` layers
+in place of the custom `Subsampling` layer which isn't a standard layer in Keras
+or TensorFlow framework, so it typically looks as follows:
+
+```python
+from tensorflow import keras
+from keras import Input, Sequential
+from keras.layers import Activation, AveragePooling2D, Conv2D, Dense, Flatten
+
+
+tanh = keras.activations.tanh
+softmax = keras.activations.softmax
+
+model = Sequential([
+    Input(shape=(28, 28, 1)),
+    Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=tanh, name='C1'),
+    AveragePooling2D(pool_size=(2, 2), strides=(2, 2), name='S2'),
+    Activation(tanh, name='S2_act'),
+    Conv2D(filters=16, kernel_size=(5, 5), activation=tanh, name='C3'),
+    subsampling(pool_size=(2, 2), strides=(2, 2), name='S4'),
+    Activation(tanh, name='S4_act'),
+    Conv2D(filters=120, kernel_size=(5, 5), activation=tanh, name='C5'),
+    Flatten(name='Flatten'),
+    Dense(84, activation=tanh, name='F6'),
+    Dense(10, activation=softmax, name='Output'),
+], name='LeNet-5')
+```
+
+Some folks end up using ReLU activation function instead of $\tanh$, some folks
+use a `Dense` layer instead of `Conv2D` for the `C5` layer, etc., leading to a
+number of variations.
+
+One way to approach this is to create a generalized version of LeNet and allow
+customization of the model, e.g., by providing a constructor function that lets
+you have a custom subsampling layer and a custom activation function for
+intermediate layers:
+
+```python
+import tensorflow as tf
+from tensorflow import keras
+from keras import Input, Sequential
+from keras.layers import Activation, AveragePooling2D, Conv2D, Dense, Flatten, Layer, MaxPooling2D
+
+from typing import Callable, Type
+
+
+def LeNet(subsampling: Type[keras.layers.Layer] = AveragePooling2D,
+          activation: Callable[[tf.Tensor], tf.Tensor] = keras.activations.tanh) -> Sequential:
+    return Sequential([
+        Input(shape=(28, 28, 1)),
+        Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=activation, name='C1'),
+        subsampling(pool_size=(2, 2), strides=(2, 2), name='S2'),
+        Activation(activation, name='S2_act'),
+        Conv2D(filters=16, kernel_size=(5, 5), activation=activation, name='C3'),
+        subsampling(pool_size=(2, 2), strides=(2, 2), name='S4'),
+        Activation(activation, name='S4_act'),
+        Conv2D(filters=120, kernel_size=(5, 5), activation=activation, name='C5'),
+        Flatten(name='Flatten'),
+        Dense(84, activation=activation, name='F6'),
+        Dense(10, activation=keras.activations.softmax, name='Output'),
+    ], name='LeNet-5')
+```
+
+> Note: the last layer **must** have a `softmax` activation to provide
+> probabilities for the 10 output nodes.
+
+With the above code in hand (also available in [`lenet.py`](lenet.py) in this
+directory), we can now construct various versions of the model very easily:
+
+```python
+from keras.layers import AveragePooling2D, MaxPooling2D
+from keras.activations import relu
+
+from lenet import LeNet # local import
+
+# Standard models with AveragePooling2D or MaxPooling2D and tanh
+model_avg = LeNet(subsampling=AveragePooling2D)
+model_max = LeNet(subsampling=MaxPooling2D)
+
+# Models with AveragePooling2D or MaxPooling2D and ReLU
+reli = keras.activations.relu
+model_avg = LeNet(subsampling=AveragePooling2D, activation=relu)
+model_max = LeNet(subsampling=MaxPooling2D, activation=relu)
+```
+
+We can also try other activation functions, e.g., [sigmoid][sigmoid-fn],
+[selu][selu-fn], [elu][elu-fn], or write our own custom one and provide it as a
+parameter to `LeNet()`.
+
+## Subsampling layer
+
+Finally, we can also implement the [`Subsampling`](subsampling.py) layer as
+described in the LeNet paper as well as the custom [scaled `tanh` activation
+function](activations.py), and easily construct a LeNet model using these
+parameters:
+
+```python
+# All local imports.
+from activations import scaled_tanh
+from lenet import LeNet
+from subsampling import Subsampling
+
+
+model = LeNet(subsampling=Subsampling, activation=scaled_tanh)
+```
+
+While implementing the Subsampling layer, we also implemented an extension which
+can be found in [`subsampling_ext.py`](subsampling_ext.py): this version has a
+(weight, bias) pair of parameters for each cell in the output, rather than just
+a single pair of parameters (per channel) for the layer overall as described in
+the LeNet paper.
+
+Basic testing did not show a significant improvement in accuracy, but with any
+increase in parameters, it does increase the training time.
+
+## Implementation versions
+
+We've tried to structure the v1, v2, v3, etc. notebooks as impleementations
+which asymptotically approach the LeNet paper, each one implementing more
+details in the LeNet paper than the previous. The table of versions in the
+[`README.md`](README.md) shows the parameters that distinguish each
+implementation from each other.
+
+We've factored out common MNIST dataset processing details into a separate
+library in [`../datasets/mnist`](../datasets/mnist) as well as the model
+definition into [`lenet.py`](lenet.py) for easier reuse of common functionality
+and to avoid code duplication. Thus, the notebooks are rather terse and not
+entirely self-contained; if you want to see that version, it can be found in the
+version control history of these files.
+
+
+[sigmoid-fn]: https://keras.io/api/layers/activations/#sigmoid-function
+[selu-fn]: https://keras.io/api/layers/activations/#selu-function
+[elu-fn]: https://keras.io/api/layers/activations/#elu-function

--- a/lenet/subsampling_ext.py
+++ b/lenet/subsampling_ext.py
@@ -1,0 +1,153 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Extension of the Subsampling layer defined in the LeNet paper.
+
+This layer has a (weight, bias) pair of parameters for each cell in the
+output, rather than just a single pair of parameters (per channel) for
+the layer overall as described in the LeNet paper.
+"""
+
+from math import ceil
+from typing import Callable, List, Optional, Tuple, Union
+
+import numpy as np
+
+import tensorflow as tf
+from tensorflow import keras
+from keras.layers import Layer
+
+
+class ArgumentError(ValueError):
+    pass
+
+
+def identity(x: tf.Tensor) -> tf.Tensor:
+    return x
+
+
+class SubsamplingPerKernelParam(Layer):
+    pool_size: Tuple[int, int]
+    strides: Tuple[int, int]
+    padding: str
+    activation: Callable[[tf.Tensor], tf.Tensor]
+    w: np.ndarray
+    b: np.ndarray
+
+    def __init__(
+        self,
+        pool_size: Union[int, List[int], Tuple[int, int]] = (2, 2),
+        strides: Optional[Union[int, List[int], Tuple[int, int]]] = None,
+        padding: str = 'VALID',
+        activation: Callable[[tf.Tensor], tf.Tensor] = identity,
+        **kwargs):
+        """Extended version of the Subsampling layer described in the LeNet paper.
+
+        This layer has a (weight, bias) pair of parameters for each cell in the
+        output, rather than just a single pair of parameters (per channel) for
+        the layer overall as described in the LeNet paper.
+
+        This layer is not a simple average or max pooling that are typically
+        used to implement LeNet: neither average-pooling nor max-pooling have
+        any trainable parameters, while the subsampling layer described in the
+        LeNet paper *does* have trainable parameters.
+
+        Note: assumes data format is `(batch_size, rows, cols, channels)`, i.e.,
+        what TensorFlow / Keras describe as "channels_last".
+
+        Args:
+          pool_size: int or 2-tuple specifying pool size (aka kernel size)
+          strides: int or 2-tuple; if unspecified, will be copied from
+            `pool_size`
+          padding: the string "VALID" or the string "SAME"
+        """
+        super().__init__(**kwargs)
+
+        if isinstance(pool_size, int):
+            self.pool_size = (pool_size, pool_size)
+        elif (isinstance(pool_size, list) or
+              isinstance(pool_size, tuple)) and len(pool_size) == 2:
+            self.pool_size = (pool_size[0], pool_size[1])
+        else:
+            raise ArgumentError(
+                f"`pool_size` must be an int or 2-tuple; received: {pool_size}")
+
+        if strides is None:
+            self.strides == self.pool_size
+        elif isinstance(strides, int):
+            self.strides = (strides, strides)
+        elif (isinstance(strides, list) or
+              isinstance(strides, tuple)) and len(strides) == 2:
+            self.strides = (strides[0], strides[1])
+        else:
+            raise ArgumentError(
+                f"`strides` must be an int or 2-tuple; received: {strides}")
+
+        assert padding is not None and padding.upper() in ('VALID', 'SAME'), (
+            f"`padding` must be either 'VALID' or 'SAME'; received: {padding}")
+        self.padding = padding.upper()
+
+        self.activation = activation
+
+    def build(self, input_shape: Tuple[Optional[int], int, int, int]) -> None:
+        """Builds internal structures to prepare for model training.
+
+        Args:
+          input_shape: length-4 tuple representing (batch_size, rows, cols,
+              channels); where `batch_size` may be None; see docs above for
+              `__init__()` for details.
+       """
+        if len(input_shape) != 4:
+            raise ArgumentError(
+                f"`len(input_shape)` != 4; received: {input_shape}")
+        if input_shape[0] is not None:
+            raise ArgumentError(
+                f"`input_shape[0] must be None; received: {input_shape}")
+
+        _, in_rows, in_cols, in_chan = input_shape
+
+        # See calculation at the bottom of this page (in the "returns" section):
+        # https://www.tensorflow.org/api_docs/python/tf/nn/pool
+        if self.padding == 'VALID':  # aka no padding
+            out_rows = ceil((in_rows - self.pool_size[0] + 1) / self.strides[0])
+            out_cols = ceil((in_cols - self.pool_size[1] + 1) / self.strides[1])
+        else:  # 'SAME'
+            out_rows = ceil(float(in_rows) / self.strides[0])
+            out_cols = ceil(float(in_cols) / self.strides[1])
+
+        output_shape = (out_rows, out_cols, in_chan)
+
+        self.w = self.add_weight(shape=output_shape,
+                                 initializer="random_normal",
+                                 trainable=True)
+
+        self.b = self.add_weight(shape=output_shape,
+                                 initializer="random_normal",
+                                 trainable=True)
+
+    def call(self, inputs: tf.Tensor) -> tf.Tensor:
+        """Computes subsampling value: `w * (sum of window entries) + b`."""
+
+        # `scale` here undoes the average pooling by getting the original sum,
+        # which is what we need, but there isn't a pooling mechanism that just
+        # gets us the sum of products.
+        scale = self.pool_size[0] * self.pool_size[1]
+        tf_scale = tf.constant(scale, dtype='float32')
+
+        avg = tf.nn.pool(inputs,
+                         window_shape=self.pool_size,
+                         pooling_type='AVG',
+                         strides=self.strides,
+                         padding=self.padding)
+
+        return self.activation(self.w * tf_scale * avg + self.b)


### PR DESCRIPTION
Also add new libraries for LeNet and include not previously-released code:

* `activations.py`: the custom scaled `tanh` activation function
* `lenet.py`: parameterized LeNet model constructor
* `subsampling_ext.py`: extension of the Subsampling layer in the paper