### PR TITLE
Ignore all Jupyter notebooks in `third_party`

### DIFF
--- a/nbconvert_test.sh
+++ b/nbconvert_test.sh
@@ -33,7 +33,7 @@ function test_file() {
   rm -f "${err}" "${html}"
 }
 
-for file in $(find . -name \*\.ipynb | sort); do
+for file in $(find . -name 'third_party' -prune -o -name '*.ipynb' -print | sort); do
   test_file "${file}"
 done
 

--- a/nbfmt_update.sh
+++ b/nbfmt_update.sh
@@ -41,6 +41,6 @@ function clean_file() {
   fi
 }
 
-for file in $(find . -name \*\.ipynb | sort); do
+for file in $(find . -name 'third_party' -prune -o -name '*.ipynb' -print | sort); do
   clean_file "${file}"
 done

--- a/run_nbfmt_test.sh
+++ b/run_nbfmt_test.sh
@@ -35,7 +35,7 @@ function test_file() {
   rm "${temp}" "${diff}"
 }
 
-for file in $(find . -name \*\.ipynb | sort); do
+for file in $(find . -name 'third_party' -prune -o -name '*.ipynb' -print | sort); do
   test_file "${file}"
 done
 

--- a/third_party/python/.gitignore
+++ b/third_party/python/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all the installed modules here ...
+*
+
+# ... but don't ignore this file!
+!.gitignore


### PR DESCRIPTION
When running format tests or automatically cleaning up or simplifying notebooks, ignore everything in the `third_party` directory as there are many notebooks there that we do not version or care to update.

Of note is that Mypy and PyType tests were already avoiding the `third_party` directory; this updates the other tests to match that behavior as well.

Also add `third_party/python/.gitignore` so that it's ignored by git as well as VS Code (which complains of too many untracked files otherwise), so that we can install Python modules into that directory without affecting our tests or tools.