### PR TITLE
LeNet: simplify notebooks via common libraries

### DIFF
--- a/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+++ b/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
@@ -41,19 +41,6 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
-        "from tensorflow import keras\n",
-        "from keras import Input, Sequential\n",
-        "from keras.layers import Activation, AveragePooling2D, MaxPooling2D, Conv2D, Dense, Flatten"
-      ]
-    },
-    {
       "cell_type": "markdown",
       "metadata": {
         "id": null
@@ -64,6 +51,22 @@
         "For one, there isn't a built-in Keras layer that matches the subsampling layer in the paper: neither `AveragePooling2D` nor `MaxPooling2D` have any trainable parameters, but the subsampling layer described in the paper does, so this is already one difference.\n",
         "\n",
         "The activation function is a more complex function than the `tanh` we're using here, but it's a reasonable approximation, and even with these changes, we get quite a good accuracy on both training and test sets."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
+      "source": [
+        "%%bash\n",
+        "\n",
+        "# Download the LeNet model constructor.\n",
+        "if ! [ -f \"lenet.py\" ]; then\n",
+        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/lenet.py\n",
+        "fi"
       ]
     },
     {
@@ -110,23 +113,15 @@
         }
       ],
       "source": [
-        "tanh = keras.activations.tanh\n",
-        "softmax = keras.activations.softmax\n",
+        "# Import our LeNet model constructor downloaded above.\n",
+        "from lenet import LeNet\n",
+        "\n",
+        "from tensorflow import keras\n",
+        "\n",
         "\n",
         "# Define the model architecture.\n",
-        "model = Sequential([\n",
-        "    Input(shape=(28, 28, 1)),\n",
-        "    Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=tanh, name='C1'),\n",
-        "    MaxPooling2D(pool_size=(2, 2), strides=(2, 2), name='S2'),\n",
-        "    Activation(tanh, name='S2_act'),\n",
-        "    Conv2D(filters=16, kernel_size=(5, 5), activation=tanh, name='C3'),\n",
-        "    MaxPooling2D(pool_size=(2, 2), strides=(2, 2), name='S4'),\n",
-        "    Activation(tanh, name='S4_act'),\n",
-        "    Conv2D(filters=120, kernel_size=(5, 5), activation=tanh, name='C5'),\n",
-        "    Flatten(name='Flatten'),\n",
-        "    Dense(84, activation=tanh, name='F6'),\n",
-        "    Dense(10, activation=softmax, name='Output'),\n",
-        "], name='LeNet-5')\n",
+        "model = LeNet(subsampling=keras.layers.MaxPooling2D,\n",
+        "              activation=keras.activations.tanh)\n",
         "\n",
         "model.summary()"
       ]

--- a/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+++ b/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
@@ -48,25 +48,14 @@
       },
       "outputs": [],
       "source": [
-        "from tensorflow import keras\n",
-        "from keras import Input, Sequential\n",
-        "from keras.layers import AveragePooling2D, Conv2D, Dense, Flatten"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
         "%%bash\n",
         "\n",
-        "# Download our custom Subsampling layer.\n",
-        "if ! [ -f \"subsampling.py\" ]; then\n",
-        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
-        "fi"
+        "# Download the custom Subsampling layer, activation function, and LeNet model.\n",
+        "for module in subsampling activations lenet ; do\n",
+        "  if ! [ -f \"${module}.py\" ]; then\n",
+        "    curl -sO \"https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/${module}.py\"\n",
+        "  fi\n",
+        "done"
       ]
     },
     {
@@ -88,9 +77,13 @@
             "                                                                 \n",
             " S2 (Subsampling)            (None, 14, 14, 6)         12        \n",
             "                                                                 \n",
+            " S2_act (Activation)         (None, 14, 14, 6)         0         \n",
+            "                                                                 \n",
             " C3 (Conv2D)                 (None, 10, 10, 16)        2416      \n",
             "                                                                 \n",
             " S4 (Subsampling)            (None, 5, 5, 16)          32        \n",
+            "                                                                 \n",
+            " S4_act (Activation)         (None, 5, 5, 16)          0         \n",
             "                                                                 \n",
             " C5 (Conv2D)                 (None, 1, 1, 120)         48120     \n",
             "                                                                 \n",
@@ -109,27 +102,16 @@
         }
       ],
       "source": [
+        "# Local imports downloaded above.\n",
         "from subsampling import Subsampling\n",
+        "from activations import scaled_tanh\n",
+        "from lenet import LeNet\n",
         "\n",
-        "def scaled_tanh(a: float) -> float:\n",
-        "    A = 1.7159\n",
-        "    S = 2. / 3\n",
-        "    return A * keras.activations.tanh(S * a)\n",
+        "from tensorflow import keras\n",
         "\n",
-        "softmax = keras.activations.softmax\n",
         "\n",
         "# Define the model architecture.\n",
-        "model = Sequential([\n",
-        "    Input(shape=(28, 28, 1)),\n",
-        "    Conv2D(filters=6, kernel_size=(5, 5), activation=scaled_tanh, padding='same', name='C1'),\n",
-        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=scaled_tanh, name='S2'),\n",
-        "    Conv2D(filters=16, kernel_size=(5, 5), activation=scaled_tanh, name='C3'),\n",
-        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=scaled_tanh, name='S4'),\n",
-        "    Conv2D(filters=120, kernel_size=(5, 5), activation=scaled_tanh, name='C5'),\n",
-        "    Flatten(name='Flatten'),\n",
-        "    Dense(84, activation=scaled_tanh, name='F6'),\n",
-        "    Dense(10, activation=softmax, name='Output'),\n",
-        "], name='LeNet-5')\n",
+        "model = LeNet(subsampling=Subsampling, activation=scaled_tanh)\n",
         "\n",
         "model.summary()"
       ]

--- a/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+++ b/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
@@ -48,25 +48,14 @@
       },
       "outputs": [],
       "source": [
-        "from tensorflow import keras\n",
-        "from keras import Input, Sequential\n",
-        "from keras.layers import AveragePooling2D, Conv2D, Dense, Flatten"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
         "%%bash\n",
         "\n",
-        "# Download our custom Subsampling layer.\n",
-        "if ! [ -f \"subsampling.py\" ]; then\n",
-        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/subsampling.py\n",
-        "fi"
+        "# Download the custom Subsampling layer, activation function, and LeNet model.\n",
+        "for module in subsampling activations lenet ; do\n",
+        "  if ! [ -f \"${module}.py\" ]; then\n",
+        "    curl -sO \"https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/${module}.py\"\n",
+        "  fi\n",
+        "done"
       ]
     },
     {
@@ -88,9 +77,13 @@
             "                                                                 \n",
             " S2 (Subsampling)            (None, 14, 14, 6)         12        \n",
             "                                                                 \n",
+            " S2_act (Activation)         (None, 14, 14, 6)         0         \n",
+            "                                                                 \n",
             " C3 (Conv2D)                 (None, 10, 10, 16)        2416      \n",
             "                                                                 \n",
             " S4 (Subsampling)            (None, 5, 5, 16)          32        \n",
+            "                                                                 \n",
+            " S4_act (Activation)         (None, 5, 5, 16)          0         \n",
             "                                                                 \n",
             " C5 (Conv2D)                 (None, 1, 1, 120)         48120     \n",
             "                                                                 \n",
@@ -109,27 +102,16 @@
         }
       ],
       "source": [
+        "# Local imports downloaded above.\n",
         "from subsampling import Subsampling\n",
+        "from activations import scaled_tanh\n",
+        "from lenet import LeNet\n",
         "\n",
-        "def scaled_tanh(a: float) -> float:\n",
-        "    A = 1.7159\n",
-        "    S = 2. / 3\n",
-        "    return A * keras.activations.tanh(S * a)\n",
+        "from tensorflow import keras\n",
         "\n",
-        "softmax = keras.activations.softmax\n",
         "\n",
         "# Define the model architecture.\n",
-        "model = Sequential([\n",
-        "    Input(shape=(28, 28, 1)),\n",
-        "    Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=scaled_tanh, name='C1'),\n",
-        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=scaled_tanh, name='S2'),\n",
-        "    Conv2D(filters=16, kernel_size=(5, 5), activation=scaled_tanh, name='C3'),\n",
-        "    Subsampling(pool_size=(2, 2), strides=(2, 2), activation=scaled_tanh, name='S4'),\n",
-        "    Conv2D(filters=120, kernel_size=(5, 5), activation=scaled_tanh, name='C5'),\n",
-        "    Flatten(name='Flatten'),\n",
-        "    Dense(84, activation=scaled_tanh, name='F6'),\n",
-        "    Dense(10, activation=softmax, name='Output'),\n",
-        "], name='LeNet-5')\n",
+        "model = LeNet(subsampling=Subsampling, activation=scaled_tanh)\n",
         "\n",
         "model.summary()"
       ]


### PR DESCRIPTION
Having created the LeNet model construction module as well as a module for the scaled `tanh` activation function, we can now remove the manual LeNet model construction and also remove all the extra TensorFlow and Keras imports as the libraries can do all of this for us, and we just have a few lines of code to download the libraries, import them, and call them with the right parameters.

The recently added implementation notes docs walk through the evolution of the code, so we can skip the tedious repetition of the same code, which needs to be updated 3 times (at least!) whenever we make a change or a cleanup.

Now, this can be done in just one (centralized) place.