### PR TITLE
Run all tests with Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,11 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ['ubuntu-latest']
-        python: ['3.10']
+        os: ['ubuntu-22.04']
+        python: ['3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} with Python ${{ matrix.python }}
 
     steps:
 


### PR DESCRIPTION
Also, replace `ubuntu-latest` with the now-current `ubuntu-22.04` so that we can manually update Ubuntu versions rather than having it silently update without our knowledge in the future.