### PR TITLE
Use native Python `list` and `tuple` types

### DIFF
--- a/lenet/subsampling.py
+++ b/lenet/subsampling.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 """Subsampling layer as defined in the LeNet paper."""
 
-from typing import Callable, List, Optional, Tuple, Union
+# From Python 3.9 and onward, `tuple`, `list` and other collection classes can
+# also function as generic class types (see PEP 585).
+#
+# Once we no longer need to support Python 3.7 or 3.8, we can remove this syntax
+# (added in PEP 563) for Python 3.7 and higher.
+from __future__ import annotations
+
+from typing import Callable, Optional, Union
 
 import numpy as np
 
@@ -31,8 +38,8 @@ def identity(x: tf.Tensor) -> tf.Tensor:
 
 
 class Subsampling(Layer):
-    pool_size: Tuple[int, int]
-    strides: Tuple[int, int]
+    pool_size: tuple[int, int]
+    strides: tuple[int, int]
     padding: str
     activation: Callable[[tf.Tensor], tf.Tensor]
     w: np.ndarray
@@ -40,8 +47,8 @@ class Subsampling(Layer):
 
     def __init__(
         self,
-        pool_size: Union[int, List[int], Tuple[int, int]] = (2, 2),
-        strides: Optional[Union[int, List[int], Tuple[int, int]]] = None,
+        pool_size: Union[int, list[int], tuple[int, int]] = (2, 2),
+        strides: Optional[Union[int, list[int], tuple[int, int]]] = None,
         padding: str = 'VALID',
         activation: Callable[[tf.Tensor], tf.Tensor] = identity,
         **kwargs):
@@ -90,7 +97,7 @@ class Subsampling(Layer):
         self.activation = activation
 
     def build(
-        self, input_shape: Tuple[Optional[int], int, int, int]) -> None:
+        self, input_shape: tuple[Optional[int], int, int, int]) -> None:
         """Builds internal structures to prepare for model training.
 
         Args:

--- a/lenet/subsampling_ext.py
+++ b/lenet/subsampling_ext.py
@@ -18,8 +18,15 @@ output, rather than just a single pair of parameters (per channel) for
 the layer overall as described in the LeNet paper.
 """
 
+# From Python 3.9 and onward, `tuple`, `list` and other collection classes can
+# also function as generic class types (see PEP 585).
+#
+# Once we no longer need to support Python 3.7 or 3.8, we can remove this syntax
+# (added in PEP 563) for Python 3.7 and higher.
+from __future__ import annotations
+
 from math import ceil
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 
@@ -37,8 +44,8 @@ def identity(x: tf.Tensor) -> tf.Tensor:
 
 
 class SubsamplingPerKernelParam(Layer):
-    pool_size: Tuple[int, int]
-    strides: Tuple[int, int]
+    pool_size: tuple[int, int]
+    strides: tuple[int, int]
     padding: str
     activation: Callable[[tf.Tensor], tf.Tensor]
     w: np.ndarray
@@ -46,8 +53,8 @@ class SubsamplingPerKernelParam(Layer):
 
     def __init__(
         self,
-        pool_size: Union[int, List[int], Tuple[int, int]] = (2, 2),
-        strides: Optional[Union[int, List[int], Tuple[int, int]]] = None,
+        pool_size: Union[int, list[int], tuple[int, int]] = (2, 2),
+        strides: Optional[Union[int, list[int], tuple[int, int]]] = None,
         padding: str = 'VALID',
         activation: Callable[[tf.Tensor], tf.Tensor] = identity,
         **kwargs):
@@ -99,7 +106,7 @@ class SubsamplingPerKernelParam(Layer):
 
         self.activation = activation
 
-    def build(self, input_shape: Tuple[Optional[int], int, int, int]) -> None:
+    def build(self, input_shape: tuple[Optional[int], int, int, int]) -> None:
         """Builds internal structures to prepare for model training.
 
         Args:


### PR DESCRIPTION
Starting with Python 3.9, we can use native `list` and `tuple` types for type annotations, rather than having to import and use `List` and `Tuple`. For Python versions prior to 3.9, we need to `from __future__ import annotations` to make this work.

Since we've recently added testing with Python 3.9 and 3.9, we'll ensure this works in practice with the various typechecking tooling we're using before merging this change.