### PR TITLE
AlexNet: properly handle existing LRN module file

### DIFF
--- a/alexnet/AlexNet_for_CIFAR-10_in_Keras_with_tf_nn_LocalResponseNormalization.ipynb
+++ b/alexnet/AlexNet_for_CIFAR-10_in_Keras_with_tf_nn_LocalResponseNormalization.ipynb
@@ -64,9 +64,11 @@
       },
       "outputs": [],
       "source": [
-        "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/local_response_normalization.py\n",
+        "%%bash\n",
         "\n",
-        "from local_response_normalization import LocalResponseNormalization"
+        "if ! [ -f \"local_response_normalization.py\" ]; then\n",
+        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/local_response_normalization.py\n",
+        "fi"
       ]
     },
     {
@@ -115,6 +117,8 @@
         }
       ],
       "source": [
+        "from local_response_normalization import LocalResponseNormalization\n",
+        "\n",
         "# Define the model architecture, this comes from the the Google Code project\n",
         "# mentioned in the paper \u2014 https://code.google.com/p/cuda-convnet/ \u2014\n",
         "# specifically, the file `examples-layers/layers-conv-local-11pct.cfg`.\n",

--- a/alexnet/AlexNet_for_CIFAR-10_with_Pylearn2_Keras_LRN.ipynb
+++ b/alexnet/AlexNet_for_CIFAR-10_with_Pylearn2_Keras_LRN.ipynb
@@ -64,10 +64,16 @@
       },
       "outputs": [],
       "source": [
-        "# Download the Pylearn2/Keras implementation of LocalResponseNormalization.\n",
-        "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/third_party/pylearn2/local_response_normalization.py\n",
+        "%%bash\n",
         "\n",
-        "from local_response_normalization import LRN2D"
+        "# Download the Pylearn2/Keras implementation of LocalResponseNormalization.\n",
+        "LRN=\"pylearn2_local_response_normalization.py\"\n",
+        "\n",
+        "if ! [ -f \"${LRN}\" ]; then\n",
+        "  # We save the target file under a different name, as we already have a file\n",
+        "  # by the name of `local_response_normalization.py` in the current directory.\n",
+        "  curl -s -o \"${LRN}\" https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/third_party/pylearn2/local_response_normalization.py\n",
+        "fi"
       ]
     },
     {
@@ -114,6 +120,8 @@
         }
       ],
       "source": [
+        "from pylearn2_local_response_normalization import LRN2D\n",
+        "\n",
         "# Define the model architecture, this comes from the the Google Code project\n",
         "# mentioned in the paper \u2014 https://code.google.com/p/cuda-convnet/ \u2014\n",
         "# specifically, the file `examples-layers/layers-conv-local-11pct.cfg`.\n",

--- a/alexnet/Basic_AlexNet_in_Keras.ipynb
+++ b/alexnet/Basic_AlexNet_in_Keras.ipynb
@@ -48,12 +48,9 @@
       },
       "outputs": [],
       "source": [
-        "import numpy as np\n",
-        "import tensorflow as tf\n",
         "from tensorflow import keras\n",
         "from keras import Input, Sequential\n",
-        "from keras.layers import Conv2D, Dense, Dropout, Flatten, MaxPool2D\n",
-        "from matplotlib import pyplot as plt"
+        "from keras.layers import Conv2D, Dense, Dropout, Flatten, MaxPool2D"
       ]
     },
     {
@@ -64,9 +61,11 @@
       },
       "outputs": [],
       "source": [
-        "!curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/local_response_normalization.py\n",
+        "%%bash\n",
         "\n",
-        "from local_response_normalization import LocalResponseNormalization"
+        "if ! [ -f \"local_response_normalization.py\" ]; then\n",
+        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/local_response_normalization.py\n",
+        "fi"
       ]
     },
     {
@@ -127,6 +126,8 @@
         }
       ],
       "source": [
+        "from local_response_normalization import LocalResponseNormalization\n",
+        "\n",
         "# Define the model architecture.\n",
         "model = Sequential([\n",
         "    Input(shape=(227, 227, 3)),\n",


### PR DESCRIPTION
Only download if there isn't a local file by that name (which can happen in a hosted environment such as Colab, Kaggle, or Binder), but not when running locally, since the file is in the same directory as the notebook.

Also, when downloading another implementation from `third_party`, rename the file so it doesn't override the local file by the same name.