### PR TITLE
AlexNet: move model definition into Python modules

### DIFF
--- a/alexnet/AlexNet_for_CIFAR-10_in_Keras_with_tf_nn_LocalResponseNormalization.ipynb
+++ b/alexnet/AlexNet_for_CIFAR-10_in_Keras_with_tf_nn_LocalResponseNormalization.ipynb
@@ -48,27 +48,15 @@
       },
       "outputs": [],
       "source": [
-        "import numpy as np\n",
-        "import tensorflow as tf\n",
-        "from tensorflow import keras\n",
-        "from keras import Input, Sequential\n",
-        "from keras.layers import Conv2D, Dense, Dropout, Flatten, MaxPool2D\n",
-        "from matplotlib import pyplot as plt"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
         "%%bash\n",
         "\n",
-        "if ! [ -f \"local_response_normalization.py\" ]; then\n",
-        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/local_response_normalization.py\n",
-        "fi"
+        "# Download the AlexNet CIFAR-10 model definition and LocalResponseNormalization\n",
+        "# layer needed to construct it.\n",
+        "for module in alexnet_cifar10 local_response_normalization ; do\n",
+        "  if ! [ -f \"${module}.py\" ]; then\n",
+        "    curl -sO \"https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/${module}.py\"\n",
+        "  fi\n",
+        "done"
       ]
     },
     {
@@ -117,25 +105,9 @@
         }
       ],
       "source": [
-        "from local_response_normalization import LocalResponseNormalization\n",
+        "import alexnet_cifar10\n",
         "\n",
-        "# Define the model architecture, this comes from the the Google Code project\n",
-        "# mentioned in the paper \u2014 https://code.google.com/p/cuda-convnet/ \u2014\n",
-        "# specifically, the file `examples-layers/layers-conv-local-11pct.cfg`.\n",
-        "model = Sequential([\n",
-        "    Input(shape=(32, 32, 3)),\n",
-        "    Conv2D(filters=64, kernel_size=5, strides=1, padding='same', activation='relu', name='Conv1'),\n",
-        "    MaxPool2D(pool_size=3, strides=2, padding='valid', name='MaxPool1'),\n",
-        "    LocalResponseNormalization(name='LRN1'),\n",
-        "    Conv2D(filters=64, kernel_size=(5, 5), padding='same', activation='relu', name='Conv2'),\n",
-        "    LocalResponseNormalization(name='LRN2'),\n",
-        "    MaxPool2D(pool_size=3, strides=2, padding='valid', name='MaxPool2'),\n",
-        "    Conv2D(filters=64, kernel_size=3, padding='same', activation='relu', name='Local3'),\n",
-        "    Conv2D(filters=32, kernel_size=3, padding='same', activation='relu', name='Local4'),\n",
-        "    Flatten(name='Flatten'),\n",
-        "    Dense(10, activation='softmax', name='FC10'),\n",
-        "], name='CIFAR-10-TF-NN-LRN')\n",
-        "\n",
+        "model = alexnet_cifar10.AlexNet()\n",
         "model.summary()"
       ]
     },
@@ -180,10 +152,12 @@
       },
       "outputs": [],
       "source": [
+        "from tensorflow import keras\n",
+        "\n",
         "# Compile the model with optimizer and loss function.\n",
-        "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
-        "loss_fn = keras.losses.CategoricalCrossentropy()\n",
-        "model.compile(optimizer=opt, loss=loss_fn, metrics=['accuracy'])"
+        "model.compile(optimizer=keras.optimizers.Adam(learning_rate=0.001),\n",
+        "              loss=keras.losses.CategoricalCrossentropy(),\n",
+        "              metrics=[keras.metrics.CategoricalAccuracy()])"
       ]
     },
     {

--- a/alexnet/AlexNet_for_CIFAR-10_with_Pylearn2_Keras_LRN.ipynb
+++ b/alexnet/AlexNet_for_CIFAR-10_with_Pylearn2_Keras_LRN.ipynb
@@ -48,32 +48,26 @@
       },
       "outputs": [],
       "source": [
-        "import numpy as np\n",
-        "import tensorflow as tf\n",
-        "from tensorflow import keras\n",
-        "from keras import Input, Sequential\n",
-        "from keras.layers import Conv2D, Dense, Dropout, Flatten, MaxPool2D\n",
-        "from matplotlib import pyplot as plt"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
         "%%bash\n",
         "\n",
-        "# Download the Pylearn2/Keras implementation of LocalResponseNormalization.\n",
-        "LRN=\"pylearn2_local_response_normalization.py\"\n",
-        "\n",
-        "if ! [ -f \"${LRN}\" ]; then\n",
+        "# Download the Pylearn2/Keras implementation of LocalResponseNormalization. We\n",
+        "# will use this layer below, even though the other implementation of LRN is\n",
+        "# needed because it is used by default in AlexNet model definition, so it als\n",
+        "# has to be downloaded.\n",
+        "PYLEARN2_LRN=\"pylearn2_local_response_normalization.py\"\n",
+        "if ! [ -f \"${PYLEARN2_LRN}\" ]; then\n",
         "  # We save the target file under a different name, as we already have a file\n",
         "  # by the name of `local_response_normalization.py` in the current directory.\n",
-        "  curl -s -o \"${LRN}\" https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/third_party/pylearn2/local_response_normalization.py\n",
-        "fi"
+        "  curl -s -o \"${PYLEARN2_LRN}\" https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/third_party/pylearn2/local_response_normalization.py\n",
+        "fi\n",
+        "\n",
+        "# Download the AlexNet CIFAR-10 model definition and LocalResponseNormalization\n",
+        "# layer needed to construct it.\n",
+        "for module in alexnet_cifar10 local_response_normalization ; do\n",
+        "  if ! [ -f \"${module}.py\" ]; then\n",
+        "    curl -sO \"https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/${module}.py\"\n",
+        "  fi\n",
+        "done"
       ]
     },
     {
@@ -121,24 +115,9 @@
       ],
       "source": [
         "from pylearn2_local_response_normalization import LRN2D\n",
+        "import alexnet_cifar10\n",
         "\n",
-        "# Define the model architecture, this comes from the the Google Code project\n",
-        "# mentioned in the paper \u2014 https://code.google.com/p/cuda-convnet/ \u2014\n",
-        "# specifically, the file `examples-layers/layers-conv-local-11pct.cfg`.\n",
-        "model = Sequential([\n",
-        "    Input(shape=(32, 32, 3)),\n",
-        "    Conv2D(filters=64, kernel_size=5, strides=1, padding='same', activation='relu', name='Conv1'),\n",
-        "    MaxPool2D(pool_size=3, strides=2, padding='valid', name='MaxPool1'),\n",
-        "    LRN2D(name='LRN1'),\n",
-        "    Conv2D(filters=64, kernel_size=(5, 5), padding='same', activation='relu', name='Conv2'),\n",
-        "    LRN2D(name='LRN2'),\n",
-        "    MaxPool2D(pool_size=3, strides=2, padding='valid', name='MaxPool2'),\n",
-        "    Conv2D(filters=64, kernel_size=3, padding='same', activation='relu', name='Local3'),\n",
-        "    Conv2D(filters=32, kernel_size=3, padding='same', activation='relu', name='Local4'),\n",
-        "    Flatten(name='Flatten'),\n",
-        "    Dense(10, activation='softmax', name='FC10'),\n",
-        "], name='CIFAR-10-Pylearn2-Keras-LRN2D')\n",
-        "\n",
+        "model = alexnet_cifar10.AlexNet(lrn=LRN2D, lrn_name='Pylearn2-Keras-LRN2D')\n",
         "model.summary()"
       ]
     },
@@ -183,10 +162,12 @@
       },
       "outputs": [],
       "source": [
+        "from tensorflow import keras\n",
+        "\n",
         "# Compile the model with optimizer and loss function.\n",
-        "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
-        "loss_fn = keras.losses.CategoricalCrossentropy()\n",
-        "model.compile(optimizer=opt, loss=loss_fn, metrics=['accuracy'])"
+        "model.compile(optimizer=keras.optimizers.Adam(learning_rate=0.001),\n",
+        "              loss=keras.losses.CategoricalCrossentropy(),\n",
+        "              metrics=[keras.metrics.CategoricalAccuracy()])"
       ]
     },
     {

--- a/alexnet/Basic_AlexNet_in_Keras.ipynb
+++ b/alexnet/Basic_AlexNet_in_Keras.ipynb
@@ -48,24 +48,13 @@
       },
       "outputs": [],
       "source": [
-        "from tensorflow import keras\n",
-        "from keras import Input, Sequential\n",
-        "from keras.layers import Conv2D, Dense, Dropout, Flatten, MaxPool2D"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
         "%%bash\n",
         "\n",
-        "if ! [ -f \"local_response_normalization.py\" ]; then\n",
-        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/local_response_normalization.py\n",
-        "fi"
+        "for module in alexnet_imagenet local_response_normalization ; do\n",
+        "  if ! [ -f \"${module}.py\" ]; then\n",
+        "    curl -sO \"https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/${module}.py\"\n",
+        "  fi\n",
+        "done"
       ]
     },
     {
@@ -126,29 +115,9 @@
         }
       ],
       "source": [
-        "from local_response_normalization import LocalResponseNormalization\n",
+        "import alexnet_imagenet\n",
         "\n",
-        "# Define the model architecture.\n",
-        "model = Sequential([\n",
-        "    Input(shape=(227, 227, 3)),\n",
-        "    Conv2D(filters=96, kernel_size=(11, 11), strides=(4, 4), padding='valid', activation='relu', name='Conv1'),\n",
-        "    LocalResponseNormalization(name='LRN1'),\n",
-        "    MaxPool2D(pool_size=(3, 3), strides=(2, 2), padding='valid', name='MaxPool1'),\n",
-        "    Conv2D(filters=256, kernel_size=(5, 5), padding='same', activation='relu', name='Conv2'),\n",
-        "    LocalResponseNormalization(name='LRN2'),\n",
-        "    MaxPool2D(pool_size=(3, 3), strides=(2, 2), padding='valid', name='MaxPool2'),\n",
-        "    Conv2D(filters=384, kernel_size=(3, 3), padding='same', activation='relu', name='Conv3'),\n",
-        "    Conv2D(filters=384, kernel_size=(3, 3), padding='same', activation='relu', name='Conv4'),\n",
-        "    Conv2D(filters=256, kernel_size=(3, 3), padding='same', activation='relu', name='Conv5'),\n",
-        "    MaxPool2D(pool_size=(3, 3), strides=(2, 2), padding='valid', name='MaxPool3'),\n",
-        "    Flatten(name='Flatten'),\n",
-        "    Dense(4096, activation='relu', name='Dense1'),\n",
-        "    Dropout(0.5, name='Dropout1'),\n",
-        "    Dense(4096, activation='relu', name='Dense2'),\n",
-        "    Dropout(0.5, name='Dropout2'),\n",
-        "    Dense(1000, activation='softmax', name='Output'),\n",
-        "], name='AlexNet')\n",
-        "\n",
+        "model = alexnet_imagenet.AlexNet()\n",
         "model.summary()"
       ]
     }

--- a/alexnet/alexnet_cifar10.py
+++ b/alexnet/alexnet_cifar10.py
@@ -1,0 +1,38 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from local_response_normalization import LocalResponseNormalization
+
+from tensorflow import keras
+from keras import Input, Sequential
+from keras.layers import Conv2D, Dense, Dropout, Flatten, MaxPool2D
+
+from typing import Type
+
+
+def AlexNet(lrn: Type = LocalResponseNormalization,
+            lrn_name: str = 'TF-NN-LRN') -> Sequential:
+    return Sequential([
+        Input(shape=(32, 32, 3)),
+        Conv2D(filters=64, kernel_size=5, strides=1, padding='same', activation='relu', name='Conv1'),
+        MaxPool2D(pool_size=3, strides=2, padding='valid', name='MaxPool1'),
+        lrn(name='LRN1'),
+        Conv2D(filters=64, kernel_size=(5, 5), padding='same', activation='relu', name='Conv2'),
+        lrn(name='LRN2'),
+        MaxPool2D(pool_size=3, strides=2, padding='valid', name='MaxPool2'),
+        Conv2D(filters=64, kernel_size=3, padding='same', activation='relu', name='Local3'),
+        Conv2D(filters=32, kernel_size=3, padding='same', activation='relu', name='Local4'),
+        Flatten(name='Flatten'),
+        Dense(10, activation='softmax', name='FC10'),
+    ], name=f'CIFAR-10-{lrn_name}')

--- a/alexnet/alexnet_imagenet.py
+++ b/alexnet/alexnet_imagenet.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from local_response_normalization import LocalResponseNormalization
+
+from tensorflow import keras
+from keras import Input, Sequential
+from keras.layers import Conv2D, Dense, Dropout, Flatten, MaxPool2D
+
+
+def AlexNet() -> Sequential:
+    return Sequential([
+        Input(shape=(227, 227, 3)),
+        Conv2D(filters=96, kernel_size=(11, 11), strides=(4, 4), padding='valid', activation='relu', name='Conv1'),
+        LocalResponseNormalization(name='LRN1'),
+        MaxPool2D(pool_size=(3, 3), strides=(2, 2), padding='valid', name='MaxPool1'),
+        Conv2D(filters=256, kernel_size=(5, 5), padding='same', activation='relu', name='Conv2'),
+        LocalResponseNormalization(name='LRN2'),
+        MaxPool2D(pool_size=(3, 3), strides=(2, 2), padding='valid', name='MaxPool2'),
+        Conv2D(filters=384, kernel_size=(3, 3), padding='same', activation='relu', name='Conv3'),
+        Conv2D(filters=384, kernel_size=(3, 3), padding='same', activation='relu', name='Conv4'),
+        Conv2D(filters=256, kernel_size=(3, 3), padding='same', activation='relu', name='Conv5'),
+        MaxPool2D(pool_size=(3, 3), strides=(2, 2), padding='valid', name='MaxPool3'),
+        Flatten(name='Flatten'),
+        Dense(4096, activation='relu', name='Dense1'),
+        Dropout(0.5, name='Dropout1'),
+        Dense(4096, activation='relu', name='Dense2'),
+        Dropout(0.5, name='Dropout2'),
+        Dense(1000, activation='softmax', name='Output'),
+    ], name='AlexNet')


### PR DESCRIPTION
Having them available in Python makes it easier to reuse across notebooks, and across hosted services, e.g., Colab, Kaggle, Binder, etc.