### PR TITLE
Add Python 3.11 to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,10 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: ['ubuntu-22.04']
-        python: ['3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} with Python ${{ matrix.python }}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,4 @@ nbconvert ~= 7.2.5
 
 # Type checking.
 mypy ~= 0.991
-pytype ~= 2022.12.15
+pytype ~= 2024.3.19


### PR DESCRIPTION
We are not yet compatible with Python 3.12; however, we needed to update pytype
from 2022.12.15 to 2024.3.19 support Python 3.11.

Also set `fail-fast: false` to run all tests every time so we can more quickly
figure out what's working and what's not working without having to rerun them.