### PR TITLE
Rename LeNet notebooks, putting framework first

### DIFF
--- a/lenet/LeNet_Keras_v1_basic_implementation.ipynb
+++ b/lenet/LeNet_Keras_v1_basic_implementation.ipynb
@@ -29,15 +29,28 @@
         "id": null
       },
       "source": [
-        "[![View on GitHub][github-badge]][github-keras-v3] [![Open In Colab][colab-badge]][colab-keras-v3] [![Open in Binder][binder-badge]][binder-keras-v3]\n",
+        "[![View on GitHub][github-badge]][github-keras-v1] [![Open In Colab][colab-badge]][colab-keras-v1] [![Open in Binder][binder-badge]][binder-keras-v1]\n",
         "\n",
         "[github-badge]: https://img.shields.io/badge/View-on%20GitHub-blue?logo=GitHub\n",
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
-        "[github-keras-v3]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb\n",
-        "[colab-keras-v3]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb\n",
-        "[binder-keras-v3]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb"
+        "[github-keras-v1]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_Keras_v1_basic_implementation.ipynb\n",
+        "[colab-keras-v1]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_Keras_v1_basic_implementation.ipynb\n",
+        "[binder-keras-v1]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_Keras_v1_basic_implementation.ipynb"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": null
+      },
+      "source": [
+        "We will start with a very simple approximation of the network described in the paper and evolve it over time to more closely match the paper.\n",
+        "\n",
+        "For one, there isn't a built-in Keras layer that matches the subsampling layer in the paper: neither `AveragePooling2D` nor `MaxPooling2D` have any trainable parameters, but the subsampling layer described in the paper does, so this is already one difference.\n",
+        "\n",
+        "The activation function is a more complex function than the `tanh` we're using here, but it's a reasonable approximation, and even with these changes, we get quite a good accuracy on both training and test sets."
       ]
     },
     {
@@ -50,12 +63,10 @@
       "source": [
         "%%bash\n",
         "\n",
-        "# Download the custom Subsampling layer, activation function, and LeNet model.\n",
-        "for module in subsampling activations lenet ; do\n",
-        "  if ! [ -f \"${module}.py\" ]; then\n",
-        "    curl -sO \"https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/${module}.py\"\n",
-        "  fi\n",
-        "done"
+        "# Download the LeNet model constructor.\n",
+        "if ! [ -f \"lenet.py\" ]; then\n",
+        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/lenet.py\n",
+        "fi"
       ]
     },
     {
@@ -75,13 +86,13 @@
             "=================================================================\n",
             " C1 (Conv2D)                 (None, 28, 28, 6)         156       \n",
             "                                                                 \n",
-            " S2 (Subsampling)            (None, 14, 14, 6)         12        \n",
+            " S2 (MaxPooling2D)           (None, 14, 14, 6)         0         \n",
             "                                                                 \n",
             " S2_act (Activation)         (None, 14, 14, 6)         0         \n",
             "                                                                 \n",
             " C3 (Conv2D)                 (None, 10, 10, 16)        2416      \n",
             "                                                                 \n",
-            " S4 (Subsampling)            (None, 5, 5, 16)          32        \n",
+            " S4 (MaxPooling2D)           (None, 5, 5, 16)          0         \n",
             "                                                                 \n",
             " S4_act (Activation)         (None, 5, 5, 16)          0         \n",
             "                                                                 \n",
@@ -94,24 +105,23 @@
             " Output (Dense)              (None, 10)                850       \n",
             "                                                                 \n",
             "=================================================================\n",
-            "Total params: 61,750\n",
-            "Trainable params: 61,750\n",
+            "Total params: 61,706\n",
+            "Trainable params: 61,706\n",
             "Non-trainable params: 0\n",
             "_________________________________________________________________\n"
           ]
         }
       ],
       "source": [
-        "# Local imports downloaded above.\n",
-        "from subsampling import Subsampling\n",
-        "from activations import scaled_tanh\n",
+        "# Import our LeNet model constructor downloaded above.\n",
         "from lenet import LeNet\n",
         "\n",
         "from tensorflow import keras\n",
         "\n",
         "\n",
         "# Define the model architecture.\n",
-        "model = LeNet(subsampling=Subsampling, activation=scaled_tanh)\n",
+        "model = LeNet(subsampling=keras.layers.MaxPooling2D,\n",
+        "              activation=keras.activations.tanh)\n",
         "\n",
         "model.summary()"
       ]
@@ -124,35 +134,8 @@
       },
       "outputs": [],
       "source": [
-        "def scheduler(epoch: int, lr: float) -> float:\n",
-        "    if epoch < 2:\n",
-        "        eta = 0.0005\n",
-        "    elif epoch < 5:\n",
-        "        eta = 0.0002\n",
-        "    elif epoch < 8:\n",
-        "        eta = 0.0001\n",
-        "    elif epoch < 12:\n",
-        "        eta = 0.00005\n",
-        "    else:\n",
-        "        eta = 0.00001\n",
-        "\n",
-        "    mu = 0.02\n",
-        "    h_kk = 1\n",
-        "    return eta / (mu + h_kk)\n",
-        "\n",
-        "lr_callback = keras.callbacks.LearningRateScheduler(scheduler)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
         "# Compile the model with optimizer and loss function.\n",
-        "opt = keras.optimizers.Adam(learning_rate=0.0005)\n",
+        "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
         "loss_fn = keras.losses.CategoricalCrossentropy()\n",
         "model.compile(optimizer=opt, loss=loss_fn, metrics=['accuracy'])"
       ]
@@ -198,8 +181,7 @@
         "\n",
         "# This will download the MNIST dataset via the Keras library which outputs data\n",
         "# to stdout, so we silence it above to avoid extraneous output.\n",
-        "mnist_data = mnist.MNIST()\n",
-        "mnist_input_range = (-0.1, 1.175)"
+        "mnist_data = mnist.MNIST()"
       ]
     },
     {
@@ -214,60 +196,68 @@
           "output_type": "stream",
           "text": [
             "Epoch 1/20\n",
-            "1875/1875 [==============================] - 16s 4ms/step - loss: 0.3410 - accuracy: 0.8947 - lr: 4.9020e-04\n",
+            "1875/1875 [==============================] - 14s 3ms/step - loss: 0.1614 - accuracy: 0.9517\n",
             "Epoch 2/20\n",
-            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.1021 - accuracy: 0.9693 - lr: 4.9020e-04\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0543 - accuracy: 0.9833\n",
             "Epoch 3/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0568 - accuracy: 0.9829 - lr: 1.9608e-04\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0369 - accuracy: 0.9886\n",
             "Epoch 4/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0457 - accuracy: 0.9862 - lr: 1.9608e-04\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0269 - accuracy: 0.9921\n",
             "Epoch 5/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0387 - accuracy: 0.9887 - lr: 1.9608e-04\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0203 - accuracy: 0.9937\n",
             "Epoch 6/20\n",
-            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0300 - accuracy: 0.9916 - lr: 9.8039e-05\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0174 - accuracy: 0.9946\n",
             "Epoch 7/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0268 - accuracy: 0.9923 - lr: 9.8039e-05\n",
+            "1875/1875 [==============================] - 8s 4ms/step - loss: 0.0133 - accuracy: 0.9957\n",
             "Epoch 8/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0243 - accuracy: 0.9931 - lr: 9.8039e-05\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0128 - accuracy: 0.9959\n",
             "Epoch 9/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0203 - accuracy: 0.9951 - lr: 4.9020e-05\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0092 - accuracy: 0.9971\n",
             "Epoch 10/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0191 - accuracy: 0.9953 - lr: 4.9020e-05\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0091 - accuracy: 0.9966\n",
             "Epoch 11/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0181 - accuracy: 0.9956 - lr: 4.9020e-05\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0072 - accuracy: 0.9978\n",
             "Epoch 12/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0169 - accuracy: 0.9960 - lr: 4.9020e-05\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0078 - accuracy: 0.9975\n",
             "Epoch 13/20\n",
-            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0148 - accuracy: 0.9968 - lr: 9.8039e-06\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0072 - accuracy: 0.9976\n",
             "Epoch 14/20\n",
-            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0145 - accuracy: 0.9969 - lr: 9.8039e-06\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0070 - accuracy: 0.9976\n",
             "Epoch 15/20\n",
-            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0143 - accuracy: 0.9970 - lr: 9.8039e-06\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0056 - accuracy: 0.9982\n",
             "Epoch 16/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0140 - accuracy: 0.9972 - lr: 9.8039e-06\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0060 - accuracy: 0.9980\n",
             "Epoch 17/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0138 - accuracy: 0.9973 - lr: 9.8039e-06\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0057 - accuracy: 0.9979\n",
             "Epoch 18/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0137 - accuracy: 0.9972 - lr: 9.8039e-06\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0076 - accuracy: 0.9976\n",
             "Epoch 19/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0135 - accuracy: 0.9973 - lr: 9.8039e-06\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0054 - accuracy: 0.9981\n",
             "Epoch 20/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0133 - accuracy: 0.9973 - lr: 9.8039e-06\n"
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0045 - accuracy: 0.9985\n"
           ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "<keras.callbacks.History at 0x7fa774b278e0>"
+            ]
+          },
+          "execution_count": null,
+          "metadata": {},
+          "output_type": "execute_result"
         }
       ],
       "source": [
         "# Train the model.\n",
         "#\n",
-        "# In this notebook, we scale the input into the range (-0.1, 1.175) as in the\n",
-        "# paper and convert the labels y to a categorical (one-hot) encoding from the\n",
-        "# default numeric values.\n",
+        "# In this notebook, we scale the input into the range [0.0, 1.0] and convert the\n",
+        "# labels y to a categorical (one-hot) encoding from the default numeric values.\n",
         "#\n",
         "# For consistency, we use the same transformations for the test dataset below.\n",
-        "history = model.fit(mnist_data.x_train_scale_custom(mnist_input_range),\n",
-        "                    mnist_data.y_train_categorical(),\n",
-        "                    epochs=20,\n",
-        "                    callbacks=[lr_callback])"
+        "model.fit(mnist_data.x_train_scale_0_1(),\n",
+        "          mnist_data.y_train_categorical(),\n",
+        "          epochs=20)"
       ]
     },
     {
@@ -281,13 +271,13 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "313/313 [==============================] - 1s 3ms/step - loss: 0.0380 - accuracy: 0.9879\n"
+            "313/313 [==============================] - 1s 3ms/step - loss: 0.0565 - accuracy: 0.9862\n"
           ]
         },
         {
           "data": {
             "text/plain": [
-              "[0.0379730761051178, 0.9879000186920166]"
+              "[0.056457001715898514, 0.9861999750137329]"
             ]
           },
           "execution_count": null,
@@ -296,18 +286,17 @@
         }
       ],
       "source": [
-        "# Evaluate the model\n",
+        "# Evaluate the model.\n",
         "#\n",
         "# Note that we use the same input range scaling and label encoding as above.\n",
-        "model.evaluate(mnist_data.x_test_scale_custom(mnist_input_range),\n",
-        "               mnist_data.y_test_categorical())"
+        "model.evaluate(mnist_data.x_test_scale_0_1(), mnist_data.y_test_categorical())"
       ]
     }
   ],
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "name": "LeNet [v3]: Subsamping, fixed scaling, and learning rate decay in Keras"
+      "name": "LeNet [v1]: basic implementation in Keras"
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb
+++ b/lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb
@@ -35,9 +35,9 @@
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
-        "[github-keras-v2]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb\n",
-        "[colab-keras-v2]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb\n",
-        "[binder-keras-v2]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb"
+        "[github-keras-v2]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb\n",
+        "[colab-keras-v2]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb\n",
+        "[binder-keras-v2]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb"
       ]
     },
     {

--- a/lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb
+++ b/lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb
@@ -29,28 +29,15 @@
         "id": null
       },
       "source": [
-        "[![View on GitHub][github-badge]][github-keras-v1] [![Open In Colab][colab-badge]][colab-keras-v1] [![Open in Binder][binder-badge]][binder-keras-v1]\n",
+        "[![View on GitHub][github-badge]][github-keras-v3] [![Open In Colab][colab-badge]][colab-keras-v3] [![Open in Binder][binder-badge]][binder-keras-v3]\n",
         "\n",
         "[github-badge]: https://img.shields.io/badge/View-on%20GitHub-blue?logo=GitHub\n",
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
-        "[github-keras-v1]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v1_basic_impl_in_Keras.ipynb\n",
-        "[colab-keras-v1]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v1_basic_impl_in_Keras.ipynb\n",
-        "[binder-keras-v1]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v1_basic_impl_in_Keras.ipynb"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": null
-      },
-      "source": [
-        "We will start with a very simple approximation of the network described in the paper and evolve it over time to more closely match the paper.\n",
-        "\n",
-        "For one, there isn't a built-in Keras layer that matches the subsampling layer in the paper: neither `AveragePooling2D` nor `MaxPooling2D` have any trainable parameters, but the subsampling layer described in the paper does, so this is already one difference.\n",
-        "\n",
-        "The activation function is a more complex function than the `tanh` we're using here, but it's a reasonable approximation, and even with these changes, we get quite a good accuracy on both training and test sets."
+        "[github-keras-v3]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb\n",
+        "[colab-keras-v3]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb\n",
+        "[binder-keras-v3]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb"
       ]
     },
     {
@@ -63,10 +50,12 @@
       "source": [
         "%%bash\n",
         "\n",
-        "# Download the LeNet model constructor.\n",
-        "if ! [ -f \"lenet.py\" ]; then\n",
-        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/lenet.py\n",
-        "fi"
+        "# Download the custom Subsampling layer, activation function, and LeNet model.\n",
+        "for module in subsampling activations lenet ; do\n",
+        "  if ! [ -f \"${module}.py\" ]; then\n",
+        "    curl -sO \"https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/${module}.py\"\n",
+        "  fi\n",
+        "done"
       ]
     },
     {
@@ -86,13 +75,13 @@
             "=================================================================\n",
             " C1 (Conv2D)                 (None, 28, 28, 6)         156       \n",
             "                                                                 \n",
-            " S2 (MaxPooling2D)           (None, 14, 14, 6)         0         \n",
+            " S2 (Subsampling)            (None, 14, 14, 6)         12        \n",
             "                                                                 \n",
             " S2_act (Activation)         (None, 14, 14, 6)         0         \n",
             "                                                                 \n",
             " C3 (Conv2D)                 (None, 10, 10, 16)        2416      \n",
             "                                                                 \n",
-            " S4 (MaxPooling2D)           (None, 5, 5, 16)          0         \n",
+            " S4 (Subsampling)            (None, 5, 5, 16)          32        \n",
             "                                                                 \n",
             " S4_act (Activation)         (None, 5, 5, 16)          0         \n",
             "                                                                 \n",
@@ -105,23 +94,24 @@
             " Output (Dense)              (None, 10)                850       \n",
             "                                                                 \n",
             "=================================================================\n",
-            "Total params: 61,706\n",
-            "Trainable params: 61,706\n",
+            "Total params: 61,750\n",
+            "Trainable params: 61,750\n",
             "Non-trainable params: 0\n",
             "_________________________________________________________________\n"
           ]
         }
       ],
       "source": [
-        "# Import our LeNet model constructor downloaded above.\n",
+        "# Local imports downloaded above.\n",
+        "from subsampling import Subsampling\n",
+        "from activations import scaled_tanh\n",
         "from lenet import LeNet\n",
         "\n",
         "from tensorflow import keras\n",
         "\n",
         "\n",
         "# Define the model architecture.\n",
-        "model = LeNet(subsampling=keras.layers.MaxPooling2D,\n",
-        "              activation=keras.activations.tanh)\n",
+        "model = LeNet(subsampling=Subsampling, activation=scaled_tanh)\n",
         "\n",
         "model.summary()"
       ]
@@ -134,8 +124,35 @@
       },
       "outputs": [],
       "source": [
+        "def scheduler(epoch: int, lr: float) -> float:\n",
+        "    if epoch < 2:\n",
+        "        eta = 0.0005\n",
+        "    elif epoch < 5:\n",
+        "        eta = 0.0002\n",
+        "    elif epoch < 8:\n",
+        "        eta = 0.0001\n",
+        "    elif epoch < 12:\n",
+        "        eta = 0.00005\n",
+        "    else:\n",
+        "        eta = 0.00001\n",
+        "\n",
+        "    mu = 0.02\n",
+        "    h_kk = 1\n",
+        "    return eta / (mu + h_kk)\n",
+        "\n",
+        "lr_callback = keras.callbacks.LearningRateScheduler(scheduler)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
+      "source": [
         "# Compile the model with optimizer and loss function.\n",
-        "opt = keras.optimizers.Adam(learning_rate=0.001)\n",
+        "opt = keras.optimizers.Adam(learning_rate=0.0005)\n",
         "loss_fn = keras.losses.CategoricalCrossentropy()\n",
         "model.compile(optimizer=opt, loss=loss_fn, metrics=['accuracy'])"
       ]
@@ -181,7 +198,8 @@
         "\n",
         "# This will download the MNIST dataset via the Keras library which outputs data\n",
         "# to stdout, so we silence it above to avoid extraneous output.\n",
-        "mnist_data = mnist.MNIST()"
+        "mnist_data = mnist.MNIST()\n",
+        "mnist_input_range = (-0.1, 1.175)"
       ]
     },
     {
@@ -196,68 +214,60 @@
           "output_type": "stream",
           "text": [
             "Epoch 1/20\n",
-            "1875/1875 [==============================] - 14s 3ms/step - loss: 0.1614 - accuracy: 0.9517\n",
+            "1875/1875 [==============================] - 16s 4ms/step - loss: 0.3410 - accuracy: 0.8947 - lr: 4.9020e-04\n",
             "Epoch 2/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0543 - accuracy: 0.9833\n",
+            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.1021 - accuracy: 0.9693 - lr: 4.9020e-04\n",
             "Epoch 3/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0369 - accuracy: 0.9886\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0568 - accuracy: 0.9829 - lr: 1.9608e-04\n",
             "Epoch 4/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0269 - accuracy: 0.9921\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0457 - accuracy: 0.9862 - lr: 1.9608e-04\n",
             "Epoch 5/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0203 - accuracy: 0.9937\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0387 - accuracy: 0.9887 - lr: 1.9608e-04\n",
             "Epoch 6/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0174 - accuracy: 0.9946\n",
+            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0300 - accuracy: 0.9916 - lr: 9.8039e-05\n",
             "Epoch 7/20\n",
-            "1875/1875 [==============================] - 8s 4ms/step - loss: 0.0133 - accuracy: 0.9957\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0268 - accuracy: 0.9923 - lr: 9.8039e-05\n",
             "Epoch 8/20\n",
-            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0128 - accuracy: 0.9959\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0243 - accuracy: 0.9931 - lr: 9.8039e-05\n",
             "Epoch 9/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0092 - accuracy: 0.9971\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0203 - accuracy: 0.9951 - lr: 4.9020e-05\n",
             "Epoch 10/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0091 - accuracy: 0.9966\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0191 - accuracy: 0.9953 - lr: 4.9020e-05\n",
             "Epoch 11/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0072 - accuracy: 0.9978\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0181 - accuracy: 0.9956 - lr: 4.9020e-05\n",
             "Epoch 12/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0078 - accuracy: 0.9975\n",
+            "1875/1875 [==============================] - 7s 4ms/step - loss: 0.0169 - accuracy: 0.9960 - lr: 4.9020e-05\n",
             "Epoch 13/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0072 - accuracy: 0.9976\n",
+            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0148 - accuracy: 0.9968 - lr: 9.8039e-06\n",
             "Epoch 14/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0070 - accuracy: 0.9976\n",
+            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0145 - accuracy: 0.9969 - lr: 9.8039e-06\n",
             "Epoch 15/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0056 - accuracy: 0.9982\n",
+            "1875/1875 [==============================] - 7s 3ms/step - loss: 0.0143 - accuracy: 0.9970 - lr: 9.8039e-06\n",
             "Epoch 16/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0060 - accuracy: 0.9980\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0140 - accuracy: 0.9972 - lr: 9.8039e-06\n",
             "Epoch 17/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0057 - accuracy: 0.9979\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0138 - accuracy: 0.9973 - lr: 9.8039e-06\n",
             "Epoch 18/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0076 - accuracy: 0.9976\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0137 - accuracy: 0.9972 - lr: 9.8039e-06\n",
             "Epoch 19/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0054 - accuracy: 0.9981\n",
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0135 - accuracy: 0.9973 - lr: 9.8039e-06\n",
             "Epoch 20/20\n",
-            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0045 - accuracy: 0.9985\n"
+            "1875/1875 [==============================] - 6s 3ms/step - loss: 0.0133 - accuracy: 0.9973 - lr: 9.8039e-06\n"
           ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "<keras.callbacks.History at 0x7fa774b278e0>"
-            ]
-          },
-          "execution_count": null,
-          "metadata": {},
-          "output_type": "execute_result"
         }
       ],
       "source": [
         "# Train the model.\n",
         "#\n",
-        "# In this notebook, we scale the input into the range [0.0, 1.0] and convert the\n",
-        "# labels y to a categorical (one-hot) encoding from the default numeric values.\n",
+        "# In this notebook, we scale the input into the range (-0.1, 1.175) as in the\n",
+        "# paper and convert the labels y to a categorical (one-hot) encoding from the\n",
+        "# default numeric values.\n",
         "#\n",
         "# For consistency, we use the same transformations for the test dataset below.\n",
-        "model.fit(mnist_data.x_train_scale_0_1(),\n",
-        "          mnist_data.y_train_categorical(),\n",
-        "          epochs=20)"
+        "history = model.fit(mnist_data.x_train_scale_custom(mnist_input_range),\n",
+        "                    mnist_data.y_train_categorical(),\n",
+        "                    epochs=20,\n",
+        "                    callbacks=[lr_callback])"
       ]
     },
     {
@@ -271,13 +281,13 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "313/313 [==============================] - 1s 3ms/step - loss: 0.0565 - accuracy: 0.9862\n"
+            "313/313 [==============================] - 1s 3ms/step - loss: 0.0380 - accuracy: 0.9879\n"
           ]
         },
         {
           "data": {
             "text/plain": [
-              "[0.056457001715898514, 0.9861999750137329]"
+              "[0.0379730761051178, 0.9879000186920166]"
             ]
           },
           "execution_count": null,
@@ -286,17 +296,18 @@
         }
       ],
       "source": [
-        "# Evaluate the model.\n",
+        "# Evaluate the model\n",
         "#\n",
         "# Note that we use the same input range scaling and label encoding as above.\n",
-        "model.evaluate(mnist_data.x_test_scale_0_1(), mnist_data.y_test_categorical())"
+        "model.evaluate(mnist_data.x_test_scale_custom(mnist_input_range),\n",
+        "               mnist_data.y_test_categorical())"
       ]
     }
   ],
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "name": "LeNet [v1]: basic implementation in Keras"
+      "name": "LeNet [v3]: Subsamping, fixed scaling, and learning rate decay in Keras"
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/lenet/README.md
+++ b/lenet/README.md
@@ -10,11 +10,11 @@ as an extension of the custom Subsampling layer.
 
 Available implementations:
 
-|     | Description    | Input<br/>pixel<br/>range | Pooling<br/>layer | Activation | Learning<br/>rate | Library | Notebook |
-|:---:| -------------- |:-------------------------:|:-----------------:|:----------:|:-----------------:|:-------:|:--------:|
-| v1 | Basic impl | [0, 1] | MaxPool2D | tanh | 0.001 | Keras | [![View on GitHub][github-badge]][github-keras-v1] [![Open In Colab][colab-badge]][colab-keras-v1] [![Open in Binder][binder-badge]][binder-keras-v1] |
-| v2 | Custom layer,<br/>activation | [0, 1] | Subsampling | scaled<br/>tanh | 0.001 | Keras | [![View on GitHub][github-badge]][github-keras-v2] [![Open In Colab][colab-badge]][colab-keras-v2] [![Open in Binder][binder-badge]][binder-keras-v2] |
-| v3 | Custom layer,<br/>activation,<br/>scaling,<br/>learning rate | [-0.1, 1.175] | Subsampling | scaled<br/>tanh | schedule | Keras | [![View on GitHub][github-badge]][github-keras-v3] [![Open In Colab][colab-badge]][colab-keras-v3] [![Open in Binder][binder-badge]][binder-keras-v3] |
+| Framework | Approach | Description    | Input<br/>pixel<br/>range | Pooling<br/>layer | Activation | Learning<br/>rate | Notebook |
+|:---------:|:--------:|:--------------:|:-------------------------:|:-----------------:|:----------:|:-----------------:|:--------:|
+| Keras | v1 | Basic implementation | [0, 1] | MaxPool2D | tanh | 0.001 | [![View on GitHub][github-badge]][github-keras-v1] [![Open In Colab][colab-badge]][colab-keras-v1] [![Open in Binder][binder-badge]][binder-keras-v1] |
+| Keras | v2 | Custom layer,<br/>activation | [0, 1] | Subsampling | scaled<br/>tanh | 0.001 | [![View on GitHub][github-badge]][github-keras-v2] [![Open In Colab][colab-badge]][colab-keras-v2] [![Open in Binder][binder-badge]][binder-keras-v2] |
+| Keras | v3 | Custom layer,<br/>activation,<br/>scaling,<br/>learning rate | [-0.1, 1.175] | Subsampling | scaled<br/>tanh | schedule | [![View on GitHub][github-badge]][github-keras-v3] [![Open In Colab][colab-badge]][colab-keras-v3] [![Open in Binder][binder-badge]][binder-keras-v3] |
 
 Our implementation is based on the following paper:
 
@@ -37,17 +37,17 @@ See also:
 [colab-badge]: https://colab.research.google.com/assets/colab-badge.svg
 [binder-badge]: https://static.mybinder.org/badge_logo.svg
 
-[github-keras-v1]: LeNet_v1_basic_impl_in_Keras.ipynb
-[colab-keras-v1]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v1_basic_impl_in_Keras.ipynb
-[binder-keras-v1]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v1_basic_impl_in_Keras.ipynb
+[github-keras-v1]: LeNet_Keras_v1_basic_implementation.ipynb
+[colab-keras-v1]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_Keras_v1_basic_implementation.ipynb
+[binder-keras-v1]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_Keras_v1_basic_implementation.ipynb
 
-[github-keras-v2]: LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
-[colab-keras-v2]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
-[binder-keras-v2]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v2_custom_Subsampling_layer_and_activation_in_Keras.ipynb
+[github-keras-v2]: LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb
+[colab-keras-v2]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb
+[binder-keras-v2]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb
 
-[github-keras-v3]: LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
-[colab-keras-v3]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
-[binder-keras-v3]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_v3_Subsamping_fixed_scaling_and_learning_rate_decay_in_Keras.ipynb
+[github-keras-v3]: LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb
+[colab-keras-v3]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb
+[binder-keras-v3]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb
 
 [lenet-google-scholar]: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=WLN3QrAAAAAJ&citation_for_view=WLN3QrAAAAAJ:u5HHmVD_uO8C
 [lenet-wikipedia]: https://en.wikipedia.org/wiki/LeNet


### PR DESCRIPTION
This will make it easier to add PyTorch or JAX or other implementations and clearly identify them in the directory structure and the README file.