### PR TITLE
Add params for LeNet and MNIST module downloads

### DIFF
--- a/lenet/LeNet_Keras_v1_basic_implementation.ipynb
+++ b/lenet/LeNet_Keras_v1_basic_implementation.ipynb
@@ -41,16 +41,18 @@
       ]
     },
     {
-      "cell_type": "markdown",
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": null
       },
+      "outputs": [],
       "source": [
-        "We will start with a very simple approximation of the network described in the paper and evolve it over time to more closely match the paper.\n",
-        "\n",
-        "For one, there isn't a built-in Keras layer that matches the subsampling layer in the paper: neither `AveragePooling2D` nor `MaxPooling2D` have any trainable parameters, but the subsampling layer described in the paper does, so this is already one difference.\n",
-        "\n",
-        "The activation function is a more complex function than the `tanh` we're using here, but it's a reasonable approximation, and even with these changes, we get quite a good accuracy on both training and test sets."
+        "# GitHub vars to make it easier to test pull requests or different versions.\n",
+        "# Leave the defaults as-is to use the latest version in my repo.\n",
+        "github_user: str = 'mbrukman'\n",
+        "github_repo: str = 'reimplementing-ml-papers'\n",
+        "github_branch: str = 'main'"
       ]
     },
     {
@@ -61,12 +63,34 @@
       },
       "outputs": [],
       "source": [
-        "%%bash\n",
+        "%%script env GH_USER=\"$github_user\" GH_REPO=\"$github_repo\" GH_BRANCH=\"$github_branch\" bash\n",
         "\n",
         "# Download the LeNet model constructor.\n",
-        "if ! [ -f \"lenet_keras.py\" ]; then\n",
-        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/lenet_keras.py\n",
-        "fi"
+        "for module in lenet_keras ; do\n",
+        "  if ! [ -f \"${module}.py\" ]; then\n",
+        "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/lenet/${module}.py\"\n",
+        "  fi\n",
+        "done\n",
+        "\n",
+        "# Download our library for processing MNIST dataset.\n",
+        "for module in mnist ; do\n",
+        "  if ! [ -f \"${module}.py\" ]; then\n",
+        "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/datasets/mnist/${module}.py\"\n",
+        "  fi\n",
+        "done"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": null
+      },
+      "source": [
+        "We will start with a very simple approximation of the network described in the paper and evolve it over time to more closely match the paper.\n",
+        "\n",
+        "For one, there isn't a built-in Keras layer that matches the subsampling layer in the paper: neither `AveragePooling2D` nor `MaxPooling2D` have any trainable parameters, but the subsampling layer described in the paper does, so this is already one difference.\n",
+        "\n",
+        "The activation function is a more complex function than the `tanh` we're using here, but it's a reasonable approximation, and even with these changes, we get quite a good accuracy on both training and test sets."
       ]
     },
     {
@@ -159,29 +183,13 @@
       },
       "outputs": [],
       "source": [
-        "%%bash\n",
-        "\n",
-        "# Download our library for processing MNIST dataset.\n",
-        "if ! [ -f \"mnist.py\" ]; then\n",
-        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/mnist/mnist.py\n",
-        "fi"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
         "%%capture --no-stderr\n",
         "\n",
-        "import mnist\n",
+        "from mnist import MNIST\n",
         "\n",
         "# This will download the MNIST dataset via the Keras library which outputs data\n",
         "# to stdout, so we silence it above to avoid extraneous output.\n",
-        "mnist_data = mnist.MNIST()"
+        "mnist_data = MNIST()"
       ]
     },
     {
@@ -296,7 +304,7 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "name": "LeNet [v1]: basic implementation in Keras"
+      "name": "LeNet Keras v1: basic implementation"
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb
+++ b/lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb
@@ -48,12 +48,34 @@
       },
       "outputs": [],
       "source": [
-        "%%bash\n",
+        "# GitHub vars to make it easier to test pull requests or different versions.\n",
+        "# Leave the defaults as-is to use the latest version in my repo.\n",
+        "github_user: str = 'mbrukman'\n",
+        "github_repo: str = 'reimplementing-ml-papers'\n",
+        "github_branch: str = 'main'"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
+      "source": [
+        "%%script env GH_USER=\"$github_user\" GH_REPO=\"$github_repo\" GH_BRANCH=\"$github_branch\" bash\n",
         "\n",
         "# Download the custom Subsampling layer, activation function, and LeNet model.\n",
         "for module in subsampling_keras activations_keras lenet_keras ; do\n",
         "  if ! [ -f \"${module}.py\" ]; then\n",
-        "    curl -sO \"https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/${module}.py\"\n",
+        "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/lenet/${module}.py\"\n",
+        "  fi\n",
+        "done\n",
+        "\n",
+        "# Download our library for processing MNIST dataset.\n",
+        "for module in mnist ; do\n",
+        "  if ! [ -f \"${module}.py\" ]; then\n",
+        "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/datasets/mnist/${module}.py\"\n",
         "  fi\n",
         "done"
       ]
@@ -149,29 +171,13 @@
       },
       "outputs": [],
       "source": [
-        "%%bash\n",
-        "\n",
-        "# Download our library for processing MNIST dataset.\n",
-        "if ! [ -f \"mnist.py\" ]; then\n",
-        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/mnist/mnist.py\n",
-        "fi"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
         "%%capture --no-stderr\n",
         "\n",
-        "import mnist\n",
+        "from mnist import MNIST\n",
         "\n",
         "# This will download the MNIST dataset via the Keras library which outputs data\n",
         "# to stdout, so we silence it above to avoid extraneous output.\n",
-        "mnist_data = mnist.MNIST()"
+        "mnist_data = MNIST()"
       ]
     },
     {
@@ -286,7 +292,7 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "name": "LeNet [v2]: custom Subsampling layer and activation function in Keras"
+      "name": "LeNet Keras v2: custom Subsampling layer and activation function"
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb
+++ b/lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb
@@ -48,12 +48,34 @@
       },
       "outputs": [],
       "source": [
-        "%%bash\n",
+        "# GitHub vars to make it easier to test pull requests or different versions.\n",
+        "# Leave the defaults as-is to use the latest version in my repo.\n",
+        "github_user: str = 'mbrukman'\n",
+        "github_repo: str = 'reimplementing-ml-papers'\n",
+        "github_branch: str = 'main'"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": null
+      },
+      "outputs": [],
+      "source": [
+        "%%script env GH_USER=\"$github_user\" GH_REPO=\"$github_repo\" GH_BRANCH=\"$github_branch\" bash\n",
         "\n",
         "# Download the custom Subsampling layer, activation function, and LeNet model.\n",
         "for module in subsampling_keras activations_keras lenet_keras ; do\n",
         "  if ! [ -f \"${module}.py\" ]; then\n",
-        "    curl -sO \"https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/lenet/${module}.py\"\n",
+        "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/lenet/${module}.py\"\n",
+        "  fi\n",
+        "done\n",
+        "\n",
+        "# Download our library for processing MNIST dataset.\n",
+        "for module in mnist ; do\n",
+        "  if ! [ -f \"${module}.py\" ]; then\n",
+        "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/datasets/mnist/${module}.py\"\n",
         "  fi\n",
         "done"
       ]
@@ -166,22 +188,6 @@
         "For details on the MNIST dataset including a data exploration, see [MNIST directory in my repo](https://github.com/mbrukman/reimplementing-ml-papers/tree/main/datasets/mnist).\n",
         "\n",
         "Here, we will import a shared library to process the MNIST dataset into the format that we need to use below for model training and testing."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
-        "%%bash\n",
-        "\n",
-        "# Download our library for processing MNIST dataset.\n",
-        "if ! [ -f \"mnist.py\" ]; then\n",
-        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/mnist/mnist.py\n",
-        "fi"
       ]
     },
     {
@@ -307,7 +313,7 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "name": "LeNet [v3]: Subsamping, fixed scaling, and learning rate decay in Keras"
+      "name": "LeNet Keras v3: Subsamping, fixed scaling, and learning rate decay"
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION
This makes it easier to test an in-progress PR (since it will use a separate branch), as well as to pin the dependent files to a release branch or tag (once we have those) to keep the notebooks stable in the face of changing code.

Updated notebook titles to better match the filenames such that when the updated notebooks are re-downloaded from Colab, they more closely match local filenames.

No functional changes.