### PR TITLE
Rename MNIST and CIFAR-10 dataset Keras libraries

### DIFF
--- a/datasets/cifar-10/cifar10_keras.py
+++ b/datasets/cifar-10/cifar10_keras.py
@@ -11,15 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""MNIST dataset provider."""
+"""CIFAR-10 dataset provider."""
 
+# From Python 3.9 and onward, `tuple`, `list` and other collection classes can
+# also function as generic class types (see PEP 585).
+#
+# Once we no longer need to support Python 3.7 or 3.8, we can remove this syntax
+# (added in PEP 563) for Python 3.7 and higher.
 from __future__ import annotations
 
 import numpy as np
 from tensorflow import keras
 
 
-class MNIST:
+class CIFAR10:
 
     x_train_raw_data: np.ndarray
     x_test_raw_data: np.ndarray
@@ -28,7 +33,7 @@ class MNIST:
     num_classes: int
 
     def __init__(self):
-        train_data, test_data = keras.datasets.mnist.load_data()
+        train_data, test_data = keras.datasets.cifar10.load_data()
         self.x_train_raw_data, self.y_train_raw_data = train_data
         self.x_test_raw_data, self.y_test_raw_data = test_data
         self.num_classes = 10

--- a/datasets/mnist/MNIST_-_Exploratory_Data_Analysis.ipynb
+++ b/datasets/mnist/MNIST_-_Exploratory_Data_Analysis.ipynb
@@ -356,14 +356,14 @@
       "source": [
         "## Using the library to simplify input and label transformations\n",
         "\n",
-        "This directory provides [`mnist.py`][mnist-github] library which includes the\n",
+        "This directory provides [`mnist_keras.py`][mnist-github] library which includes the\n",
         "above transformations for scaling the input and converting the labels to a\n",
         "categorical (one-hot) representation from the default numeric values, so you\n",
         "can use it to simplify the data setup for training and testing MNIST models.\n",
         "\n",
         "You can see examples of how the library can be used in the [LeNet notebooks][lenet].\n",
         "\n",
-        "[mnist-github]: https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/mnist/mnist.py\n",
+        "[mnist-github]: https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/mnist/mnist_keras.py\n",
         "[lenet]: https://github.com/mbrukman/reimplementing-ml-papers/tree/main/lenet"
       ]
     }

--- a/datasets/mnist/mnist_keras.py
+++ b/datasets/mnist/mnist_keras.py
@@ -11,15 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""CIFAR-10 dataset provider."""
+"""MNIST dataset provider."""
 
+# From Python 3.9 and onward, `tuple`, `list` and other collection classes can
+# also function as generic class types (see PEP 585).
+#
+# Once we no longer need to support Python 3.7 or 3.8, we can remove this syntax
+# (added in PEP 563) for Python 3.7 and higher.
 from __future__ import annotations
 
 import numpy as np
 from tensorflow import keras
 
 
-class CIFAR10:
+class MNIST:
 
     x_train_raw_data: np.ndarray
     x_test_raw_data: np.ndarray
@@ -28,7 +33,7 @@ class CIFAR10:
     num_classes: int
 
     def __init__(self):
-        train_data, test_data = keras.datasets.cifar10.load_data()
+        train_data, test_data = keras.datasets.mnist.load_data()
         self.x_train_raw_data, self.y_train_raw_data = train_data
         self.x_test_raw_data, self.y_test_raw_data = test_data
         self.num_classes = 10

--- a/lenet/LeNet_Keras_v1_basic_implementation.ipynb
+++ b/lenet/LeNet_Keras_v1_basic_implementation.ipynb
@@ -73,7 +73,7 @@
         "done\n",
         "\n",
         "# Download our library for processing MNIST dataset.\n",
-        "for module in mnist ; do\n",
+        "for module in mnist_keras ; do\n",
         "  if ! [ -f \"${module}.py\" ]; then\n",
         "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/datasets/mnist/${module}.py\"\n",
         "  fi\n",
@@ -185,7 +185,7 @@
       "source": [
         "%%capture --no-stderr\n",
         "\n",
-        "from mnist import MNIST\n",
+        "from mnist_keras import MNIST\n",
         "\n",
         "# This will download the MNIST dataset via the Keras library which outputs data\n",
         "# to stdout, so we silence it above to avoid extraneous output.\n",

--- a/lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb
+++ b/lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb
@@ -73,7 +73,7 @@
         "done\n",
         "\n",
         "# Download our library for processing MNIST dataset.\n",
-        "for module in mnist ; do\n",
+        "for module in mnist_keras ; do\n",
         "  if ! [ -f \"${module}.py\" ]; then\n",
         "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/datasets/mnist/${module}.py\"\n",
         "  fi\n",
@@ -173,7 +173,7 @@
       "source": [
         "%%capture --no-stderr\n",
         "\n",
-        "from mnist import MNIST\n",
+        "from mnist_keras import MNIST\n",
         "\n",
         "# This will download the MNIST dataset via the Keras library which outputs data\n",
         "# to stdout, so we silence it above to avoid extraneous output.\n",

--- a/lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb
+++ b/lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb
@@ -73,7 +73,7 @@
         "done\n",
         "\n",
         "# Download our library for processing MNIST dataset.\n",
-        "for module in mnist ; do\n",
+        "for module in mnist_keras ; do\n",
         "  if ! [ -f \"${module}.py\" ]; then\n",
         "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/datasets/mnist/${module}.py\"\n",
         "  fi\n",
@@ -200,11 +200,11 @@
       "source": [
         "%%capture --no-stderr\n",
         "\n",
-        "import mnist\n",
+        "from mnist_keras import MNIST\n",
         "\n",
         "# This will download the MNIST dataset via the Keras library which outputs data\n",
         "# to stdout, so we silence it above to avoid extraneous output.\n",
-        "mnist_data = mnist.MNIST()\n",
+        "mnist_data = MNIST()\n",
         "mnist_input_range = (-0.1, 1.175)"
       ]
     },


### PR DESCRIPTION
Clarify that these libraries are Keras-specific; we may choose to add similar libraries later for other frameworks, so this will help clarify the distinction.

No functional changes.