### PR TITLE
Add Python 3.12 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-22.04']
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} with Python ${{ matrix.python }}
@@ -42,17 +42,32 @@ jobs:
         python-version: ${{ matrix.python }}
         cache: 'pip'
 
-    - name: Install Python core deps
+    - name: Install Python core deps (3.8 — 3.11)
       run: python -m pip install -r requirements.txt
+      if: ${{ matrix.python != '3.12' }}
 
-    - name: Install Python testing deps
+    - name: Install Python testing deps (3.8 — 3.11)
       run: python -m pip install -r requirements-test.txt
+      if: ${{ matrix.python != '3.12' }}
+
+    - name: Install Python core deps (3.12)
+      run: python -m pip install -r requirements-3.12.txt
+      if: ${{ matrix.python == '3.12' }}
+
+    - name: Install Python testing deps (3.12)
+      run: python -m pip install -r requirements-test-3.12.txt
+      if: ${{ matrix.python == '3.12' }}
 
     - name: Check types with Mypy
       run: make mypy-test
 
     - name: Check types with PyType
       run: make pytype-test
+      # https://github.com/google/pytype/issues/1475
+      #
+      # PyType does not yet support Python 3.12; if this step is enabled, it
+      # fails with an error: "Python versions > 3.11 are not yet supported."
+      if: ${{ matrix.python != '3.12' }}
 
     - name: Run nbconvert test
       run: make nbconvert-test

--- a/requirements-3.12.txt
+++ b/requirements-3.12.txt
@@ -1,0 +1,6 @@
+# These requirements are specifically for Python 3.12; earlier Python versions
+# accept the dependency versions in `requirements.txt`.
+
+tensorflow ~= 2.16.1
+keras ~= 3.0.0
+numpy ~= 1.26.4

--- a/requirements-test-3.12.txt
+++ b/requirements-test-3.12.txt
@@ -1,0 +1,10 @@
+# These requirements are specifically for Python 3.12; earlier Python versions
+# accept the dependency versions in `requirements.txt`.
+
+# Deps for the nbconvert test.
+jupyterlab ~= 4.1.5
+nbconvert ~= 7.16.3
+
+# Type checking.
+mypy ~= 1.9.0
+pytype ~= 2024.3.19

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,6 @@
+# These versions are compatible for Python 3.8-3.11; Python 3.12 has its own
+# dependency versions defined in `requirements-3.12.txt`.
+
 # Deps for the nbconvert test.
 jupyterlab ~= 3.6.7
 nbconvert ~= 7.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# These versions are compatible for Python 3.8-3.11; Python 3.12 has its own
+# dependency versions defined in `requirements-3.12.txt`.
+
 tensorflow ~= 2.12.0
 keras ~= 2.12.0
 numpy ~= 1.24.0


### PR DESCRIPTION
Define a separate set of dependency versions for base and test libraries for
Python 3.12 since it's so new and requires newer library versions than older
Python versions.