### PR TITLE
Combine Python vars and Bash vars cells

### DIFF
--- a/lenet/LeNet_Keras_v1_basic_implementation.ipynb
+++ b/lenet/LeNet_Keras_v1_basic_implementation.ipynb
@@ -48,22 +48,11 @@
       },
       "outputs": [],
       "source": [
-        "# GitHub vars to make it easier to test pull requests or different versions.\n",
-        "# Leave the defaults as-is to use the latest version in my repo.\n",
-        "github_user: str = 'mbrukman'\n",
-        "github_repo: str = 'reimplementing-ml-papers'\n",
-        "github_branch: str = 'main'"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
-        "%%script env GH_USER=\"$github_user\" GH_REPO=\"$github_repo\" GH_BRANCH=\"$github_branch\" bash\n",
+        "%%bash\n",
+        "\n",
+        "readonly GH_USER=\"mbrukman\"\n",
+        "readonly GH_REPO=\"reimplementing-ml-papers\"\n",
+        "readonly GH_BRANCH=\"main\"\n",
         "\n",
         "# Download the LeNet model constructor.\n",
         "for module in lenet_keras ; do\n",
@@ -129,9 +118,9 @@
             " Output (Dense)              (None, 10)                850       \n",
             "                                                                 \n",
             "=================================================================\n",
-            "Total params: 61,706\n",
-            "Trainable params: 61,706\n",
-            "Non-trainable params: 0\n",
+            "Total params: 61706 (241.04 KB)\n",
+            "Trainable params: 61706 (241.04 KB)\n",
+            "Non-trainable params: 0 (0.00 Byte)\n",
             "_________________________________________________________________\n"
           ]
         }

--- a/lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb
+++ b/lenet/LeNet_Keras_v2_custom_Subsampling_layer_and_activation.ipynb
@@ -48,22 +48,11 @@
       },
       "outputs": [],
       "source": [
-        "# GitHub vars to make it easier to test pull requests or different versions.\n",
-        "# Leave the defaults as-is to use the latest version in my repo.\n",
-        "github_user: str = 'mbrukman'\n",
-        "github_repo: str = 'reimplementing-ml-papers'\n",
-        "github_branch: str = 'main'"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
-        "%%script env GH_USER=\"$github_user\" GH_REPO=\"$github_repo\" GH_BRANCH=\"$github_branch\" bash\n",
+        "%%bash\n",
+        "\n",
+        "readonly GH_USER=\"mbrukman\"\n",
+        "readonly GH_REPO=\"reimplementing-ml-papers\"\n",
+        "readonly GH_BRANCH=\"main\"\n",
         "\n",
         "# Download the custom Subsampling layer, activation function, and LeNet model.\n",
         "for module in subsampling_keras activations_keras lenet_keras ; do\n",
@@ -116,9 +105,9 @@
             " Output (Dense)              (None, 10)                850       \n",
             "                                                                 \n",
             "=================================================================\n",
-            "Total params: 61,750\n",
-            "Trainable params: 61,750\n",
-            "Non-trainable params: 0\n",
+            "Total params: 61750 (241.21 KB)\n",
+            "Trainable params: 61750 (241.21 KB)\n",
+            "Non-trainable params: 0 (0.00 Byte)\n",
             "_________________________________________________________________\n"
           ]
         }

--- a/lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb
+++ b/lenet/LeNet_Keras_v3_Subsamping_fixed_scaling_and_learning_rate_decay.ipynb
@@ -48,22 +48,11 @@
       },
       "outputs": [],
       "source": [
-        "# GitHub vars to make it easier to test pull requests or different versions.\n",
-        "# Leave the defaults as-is to use the latest version in my repo.\n",
-        "github_user: str = 'mbrukman'\n",
-        "github_repo: str = 'reimplementing-ml-papers'\n",
-        "github_branch: str = 'main'"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
-        "%%script env GH_USER=\"$github_user\" GH_REPO=\"$github_repo\" GH_BRANCH=\"$github_branch\" bash\n",
+        "%%bash\n",
+        "\n",
+        "readonly GH_USER=\"mbrukman\"\n",
+        "readonly GH_REPO=\"reimplementing-ml-papers\"\n",
+        "readonly GH_BRANCH=\"main\"\n",
         "\n",
         "# Download the custom Subsampling layer, activation function, and LeNet model.\n",
         "for module in subsampling_keras activations_keras lenet_keras ; do\n",
@@ -116,9 +105,9 @@
             " Output (Dense)              (None, 10)                850       \n",
             "                                                                 \n",
             "=================================================================\n",
-            "Total params: 61,750\n",
-            "Trainable params: 61,750\n",
-            "Non-trainable params: 0\n",
+            "Total params: 61750 (241.21 KB)\n",
+            "Trainable params: 61750 (241.21 KB)\n",
+            "Non-trainable params: 0 (0.00 Byte)\n",
             "_________________________________________________________________\n"
           ]
         }


### PR DESCRIPTION
Since we only use the Python-defined vars in a single Bash cell for downloading files, for simplicity, we can combine the two into a single `%%bash` cell rather than define them in Python and import them in a `%%script env ... bash` cell.

This is still easy to modify in a single place, which still makes testing easy.

No functional changes.