### PR TITLE
Update AlexNet for CIFAR-10 paths; add GH params

### DIFF
--- a/alexnet/AlexNet_for_CIFAR-10_in_Keras_with_tf_nn_LocalResponseNormalization.ipynb
+++ b/alexnet/AlexNet_for_CIFAR-10_in_Keras_with_tf_nn_LocalResponseNormalization.ipynb
@@ -50,11 +50,22 @@
       "source": [
         "%%bash\n",
         "\n",
+        "readonly GH_USER=\"mbrukman\"\n",
+        "readonly GH_REPO=\"reimplementing-ml-papers\"\n",
+        "readonly GH_BRANCH=\"main\"\n",
+        "\n",
         "# Download the AlexNet CIFAR-10 model definition and LocalResponseNormalization\n",
         "# layer needed to construct it.\n",
         "for module in alexnet_cifar10 local_response_normalization ; do\n",
         "  if ! [ -f \"${module}.py\" ]; then\n",
-        "    curl -sO \"https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/${module}.py\"\n",
+        "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/alexnet/${module}.py\"\n",
+        "  fi\n",
+        "done\n",
+        "\n",
+        "# Download our library for processing the CIFAR-10 dataset.\n",
+        "for module in cifar10_keras ; do\n",
+        "  if ! [ -f \"${module}.py\" ]; then\n",
+        "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/datasets/cifar-10/${module}.py\"\n",
         "  fi\n",
         "done"
       ]
@@ -78,13 +89,13 @@
             "                                                                 \n",
             " MaxPool1 (MaxPooling2D)     (None, 15, 15, 64)        0         \n",
             "                                                                 \n",
-            " LRN1 (LocalResponseNormaliz  (None, 15, 15, 64)       0         \n",
-            " ation)                                                          \n",
+            " LRN1 (LocalResponseNormali  (None, 15, 15, 64)        0         \n",
+            " zation)                                                         \n",
             "                                                                 \n",
             " Conv2 (Conv2D)              (None, 15, 15, 64)        102464    \n",
             "                                                                 \n",
-            " LRN2 (LocalResponseNormaliz  (None, 15, 15, 64)       0         \n",
-            " ation)                                                          \n",
+            " LRN2 (LocalResponseNormali  (None, 15, 15, 64)        0         \n",
+            " zation)                                                         \n",
             "                                                                 \n",
             " MaxPool2 (MaxPooling2D)     (None, 7, 7, 64)          0         \n",
             "                                                                 \n",
@@ -97,34 +108,18 @@
             " FC10 (Dense)                (None, 10)                15690     \n",
             "                                                                 \n",
             "=================================================================\n",
-            "Total params: 178,410\n",
-            "Trainable params: 178,410\n",
-            "Non-trainable params: 0\n",
+            "Total params: 178410 (696.91 KB)\n",
+            "Trainable params: 178410 (696.91 KB)\n",
+            "Non-trainable params: 0 (0.00 Byte)\n",
             "_________________________________________________________________\n"
           ]
         }
       ],
       "source": [
-        "import alexnet_cifar10\n",
+        "from alexnet_cifar10 import AlexNet\n",
         "\n",
-        "model = alexnet_cifar10.AlexNet()\n",
+        "model = AlexNet()\n",
         "model.summary()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
-        "%%bash\n",
-        "\n",
-        "# Download our library for processing CIFAR-10 dataset.\n",
-        "if ! [ -f \"cifar10.py\" ]; then\n",
-        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/cifar-10/cifar10.py\n",
-        "fi"
       ]
     },
     {
@@ -137,11 +132,11 @@
       "source": [
         "%%capture --no-stderr\n",
         "\n",
-        "import cifar10\n",
+        "from cifar10_keras import CIFAR10\n",
         "\n",
         "# This will download the CIFAR-10 dataset via the Keras library, which writes to\n",
         "# stdout, so we silence it above to avoid extraneous output.\n",
-        "cifar10_data = cifar10.CIFAR10()"
+        "cifar10_data = CIFAR10()"
       ]
     },
     {

--- a/alexnet/AlexNet_for_CIFAR-10_with_Pylearn2_Keras_LRN.ipynb
+++ b/alexnet/AlexNet_for_CIFAR-10_with_Pylearn2_Keras_LRN.ipynb
@@ -50,22 +50,33 @@
       "source": [
         "%%bash\n",
         "\n",
+        "readonly GH_USER=\"mbrukman\"\n",
+        "readonly GH_REPO=\"reimplementing-ml-papers\"\n",
+        "readonly GH_BRANCH=\"main\"\n",
+        "\n",
         "# Download the Pylearn2/Keras implementation of LocalResponseNormalization. We\n",
         "# will use this layer below, even though the other implementation of LRN is\n",
         "# needed because it is used by default in AlexNet model definition, so it als\n",
         "# has to be downloaded.\n",
-        "PYLEARN2_LRN=\"pylearn2_local_response_normalization.py\"\n",
+        "readonly PYLEARN2_LRN=\"pylearn2_local_response_normalization.py\"\n",
         "if ! [ -f \"${PYLEARN2_LRN}\" ]; then\n",
         "  # We save the target file under a different name, as we already have a file\n",
         "  # by the name of `local_response_normalization.py` in the current directory.\n",
-        "  curl -s -o \"${PYLEARN2_LRN}\" https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/third_party/pylearn2/local_response_normalization.py\n",
+        "  curl -s -o \"${PYLEARN2_LRN}\" \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/third_party/pylearn2/local_response_normalization.py\"\n",
         "fi\n",
         "\n",
         "# Download the AlexNet CIFAR-10 model definition and LocalResponseNormalization\n",
         "# layer needed to construct it.\n",
         "for module in alexnet_cifar10 local_response_normalization ; do\n",
         "  if ! [ -f \"${module}.py\" ]; then\n",
-        "    curl -sO \"https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/${module}.py\"\n",
+        "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/alexnet/${module}.py\"\n",
+        "  fi\n",
+        "done\n",
+        "\n",
+        "# Download our library for processing the CIFAR-10 dataset.\n",
+        "for module in cifar10_keras ; do\n",
+        "  if ! [ -f \"${module}.py\" ]; then\n",
+        "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/datasets/cifar-10/${module}.py\"\n",
         "  fi\n",
         "done"
       ]
@@ -106,35 +117,19 @@
             " FC10 (Dense)                (None, 10)                15690     \n",
             "                                                                 \n",
             "=================================================================\n",
-            "Total params: 178,410\n",
-            "Trainable params: 178,410\n",
-            "Non-trainable params: 0\n",
+            "Total params: 178410 (696.91 KB)\n",
+            "Trainable params: 178410 (696.91 KB)\n",
+            "Non-trainable params: 0 (0.00 Byte)\n",
             "_________________________________________________________________\n"
           ]
         }
       ],
       "source": [
+        "from alexnet_cifar10 import AlexNet\n",
         "from pylearn2_local_response_normalization import LRN2D\n",
-        "import alexnet_cifar10\n",
         "\n",
-        "model = alexnet_cifar10.AlexNet(lrn=LRN2D, lrn_name='Pylearn2-Keras-LRN2D')\n",
+        "model = AlexNet(lrn=LRN2D, lrn_name='Pylearn2-Keras-LRN2D')\n",
         "model.summary()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": null
-      },
-      "outputs": [],
-      "source": [
-        "%%bash\n",
-        "\n",
-        "# Download our library for processing CIFAR-10 dataset.\n",
-        "if ! [ -f \"cifar10.py\" ]; then\n",
-        "  curl -sO https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/datasets/cifar-10/cifar10.py\n",
-        "fi"
       ]
     },
     {
@@ -147,11 +142,11 @@
       "source": [
         "%%capture --no-stderr\n",
         "\n",
-        "import cifar10\n",
+        "from cifar10_keras import CIFAR10\n",
         "\n",
         "# This will download the CIFAR-10 dataset via the Keras library, which writes to\n",
         "# stdout, so we silence it above to avoid extraneous output.\n",
-        "cifar10_data = cifar10.CIFAR10()"
+        "cifar10_data = CIFAR10()"
       ]
     },
     {

--- a/alexnet/AlexNet_for_ImageNet_in_Keras.ipynb
+++ b/alexnet/AlexNet_for_ImageNet_in_Keras.ipynb
@@ -35,9 +35,9 @@
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
-        "[github-basic]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/alexnet/Basic_AlexNet_in_Keras.ipynb\n",
-        "[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/alexnet/Basic_AlexNet_in_Keras.ipynb\n",
-        "[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=alexnet/Basic_AlexNet_in_Keras.ipynb"
+        "[github-basic]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/alexnet/AlexNet_for_ImageNet_in_Keras.ipynb\n",
+        "[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/alexnet/AlexNet_for_ImageNet_in_Keras.ipynb\n",
+        "[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=alexnet/AlexNet_for_ImageNet_in_Keras.ipynb"
       ]
     },
     {
@@ -50,9 +50,13 @@
       "source": [
         "%%bash\n",
         "\n",
+        "readonly GH_USER=\"mbrukman\"\n",
+        "readonly GH_REPO=\"reimplementing-ml-papers\"\n",
+        "readonly GH_BRANCH=\"main\"\n",
+        "\n",
         "for module in alexnet_imagenet local_response_normalization ; do\n",
         "  if ! [ -f \"${module}.py\" ]; then\n",
-        "    curl -sO \"https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/alexnet/${module}.py\"\n",
+        "    curl -sO \"https://raw.githubusercontent.com/${GH_USER}/${GH_REPO}/${GH_BRANCH}/alexnet/${module}.py\"\n",
         "  fi\n",
         "done"
       ]
@@ -74,15 +78,15 @@
             "=================================================================\n",
             " Conv1 (Conv2D)              (None, 55, 55, 96)        34944     \n",
             "                                                                 \n",
-            " LRN1 (LocalResponseNormaliz  (None, 55, 55, 96)       0         \n",
-            " ation)                                                          \n",
+            " LRN1 (LocalResponseNormali  (None, 55, 55, 96)        0         \n",
+            " zation)                                                         \n",
             "                                                                 \n",
             " MaxPool1 (MaxPooling2D)     (None, 27, 27, 96)        0         \n",
             "                                                                 \n",
             " Conv2 (Conv2D)              (None, 27, 27, 256)       614656    \n",
             "                                                                 \n",
-            " LRN2 (LocalResponseNormaliz  (None, 27, 27, 256)      0         \n",
-            " ation)                                                          \n",
+            " LRN2 (LocalResponseNormali  (None, 27, 27, 256)       0         \n",
+            " zation)                                                         \n",
             "                                                                 \n",
             " MaxPool2 (MaxPooling2D)     (None, 13, 13, 256)       0         \n",
             "                                                                 \n",
@@ -107,9 +111,9 @@
             " Output (Dense)              (None, 1000)              4097000   \n",
             "                                                                 \n",
             "=================================================================\n",
-            "Total params: 62,378,344\n",
-            "Trainable params: 62,378,344\n",
-            "Non-trainable params: 0\n",
+            "Total params: 62378344 (237.95 MB)\n",
+            "Trainable params: 62378344 (237.95 MB)\n",
+            "Non-trainable params: 0 (0.00 Byte)\n",
             "_________________________________________________________________\n"
           ]
         }
@@ -124,7 +128,7 @@
   ],
   "metadata": {
     "colab": {
-      "name": "Basic AlexNet in Keras"
+      "name": "AlexNet for ImageNet in Keras"
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/alexnet/README.md
+++ b/alexnet/README.md
@@ -111,9 +111,9 @@ Here are several references which agree on this analysis of input shape:
 [colab-cifar10-tf-nn-lrn]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/alexnet/AlexNet_for_CIFAR-10_in_Keras_with_tf_nn_LocalResponseNormalization.ipynb
 [binder-cifar10-tf-nn-lrn]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=alexnet/AlexNet_for_CIFAR-10_in_Keras_with_tf_nn_LocalResponseNormalization.ipynb
 
-[github-basic]: Basic_AlexNet_in_Keras.ipynb
-[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/alexnet/Basic_AlexNet_in_Keras.ipynb
-[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=alexnet/Basic_AlexNet_in_Keras.ipynb
+[github-basic]: AlexNet_for_ImageNet_in_Keras.ipynb
+[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/alexnet/AlexNet_for_ImageNet_in_Keras.ipynb
+[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=alexnet/AlexNet_for_ImageNet_in_Keras.ipynb
 
 [neurips-alexnet]: https://papers.nips.cc/paper/2012/hash/c399862d3b9d6b76c8436e924a68c45b-Abstract.html
 [acm-alexnet]: https://dl.acm.org/doi/10.5555/2999134.2999257


### PR DESCRIPTION
* Update imports of the CIFAR-10 library to take into account earlier renaming from `cifar10.py` to `cifar_keras.py` to clarify the library compatibility.

* Add `$GH_{USER,REPO,BRANCH}` shell vars to make it easier to try out different versions using in-progres pull requests or retarget to another fork or repo easily.