### PR TITLE
Move GoogLeNet notebook into `keras` subdirectory

### DIFF
--- a/googlenet/README.md
+++ b/googlenet/README.md
@@ -12,13 +12,7 @@ and implement the network. See the directory's documentation for details.
 
 Available implementations:
 
-|      | Description    | Library | Notebook |
-|:----:| -------------- |:-------:|:--------:|
-|  v1  | Basic impl     |  Keras  | [![View on GitHub][github-badge]][github-basic] [![Open In Colab][colab-badge]][colab-basic] [![Open in Binder][binder-badge]][binder-basic] |
-
-Implementation notes for v1:
-
-1. We haven't yet trained or tested this network (work in progress).
+* [Keras](keras)
 
 Our implementation is based on the following paper:
 
@@ -35,14 +29,6 @@ You can access this paper via:
 See also:
 
 * [Papers with Code][pwc-googlenet]
-
-[github-badge]: https://img.shields.io/badge/View-on%20GitHub-blue?logo=GitHub
-[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg
-[binder-badge]: https://static.mybinder.org/badge_logo.svg
-
-[github-basic]: GoogLeNet_implementation_in_Keras.ipynb
-[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/googlenet/GoogLeNet_implementation_in_Keras.ipynb
-[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=googlenet/GoogLeNet_implementation_in_Keras.ipynb
 
 [arxiv-googlenet]: https://arxiv.org/abs/1409.4842
 [scholar-googlenet]: https://scholar.google.com/scholar_lookup?arxiv_id=1409.4842

--- a/googlenet/keras/GoogLeNet_implementation_in_Keras.ipynb
+++ b/googlenet/keras/GoogLeNet_implementation_in_Keras.ipynb
@@ -35,9 +35,9 @@
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
-        "[github-basic]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/googlenet/GoogLeNet_implementation_in_Keras.ipynb\n",
-        "[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/googlenet/GoogLeNet_implementation_in_Keras.ipynb\n",
-        "[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=googlenet/GoogLeNet_implementation_in_Keras.ipynb"
+        "[github-basic]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/googlenet/keras/GoogLeNet_implementation_in_Keras.ipynb\n",
+        "[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/googlenet/keras/GoogLeNet_implementation_in_Keras.ipynb\n",
+        "[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=googlenet/keras/GoogLeNet_implementation_in_Keras.ipynb"
       ]
     },
     {

--- a/googlenet/keras/README.md
+++ b/googlenet/keras/README.md
@@ -1,0 +1,19 @@
+# GoogLeNet in Keras
+
+Available implementations:
+
+|      | Description  | Notebook |
+|:----:|:------------:|:--------:|
+|  v1  | Basic impl   | [![View on GitHub][github-badge]][github-basic] [![Open In Colab][colab-badge]][colab-basic] [![Open in Binder][binder-badge]][binder-basic] |
+
+Implementation notes for v1:
+
+1. We haven't yet trained or tested this network (work in progress).
+
+[github-badge]: https://img.shields.io/badge/View-on%20GitHub-blue?logo=GitHub
+[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg
+[binder-badge]: https://static.mybinder.org/badge_logo.svg
+
+[github-basic]: GoogLeNet_implementation_in_Keras.ipynb
+[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/googlenet/keras/GoogLeNet_implementation_in_Keras.ipynb
+[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=googlenet/keras/GoogLeNet_implementation_in_Keras.ipynb


### PR DESCRIPTION
This will make it easier for us to add parallel implementations in other ML frameworks such as PyTorch without creating confusion, as we'll be also adding Python files to the directory and don't want to mix-and-match them.