### PR TITLE
Simplify GoogLeNet v1 Keras notebook filename

### DIFF
--- a/googlenet/keras/GoogLeNet_v1.ipynb
+++ b/googlenet/keras/GoogLeNet_v1.ipynb
@@ -35,9 +35,9 @@
         "[colab-badge]: https://colab.research.google.com/assets/colab-badge.svg\n",
         "[binder-badge]: https://static.mybinder.org/badge_logo.svg\n",
         "\n",
-        "[github-basic]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/googlenet/keras/GoogLeNet_implementation_in_Keras.ipynb\n",
-        "[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/googlenet/keras/GoogLeNet_implementation_in_Keras.ipynb\n",
-        "[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=googlenet/keras/GoogLeNet_implementation_in_Keras.ipynb"
+        "[github-basic]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/googlenet/keras/GoogLeNet_v1.ipynb\n",
+        "[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/googlenet/keras/GoogLeNet_v1.ipynb\n",
+        "[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=googlenet/keras/GoogLeNet_v1.ipynb"
       ]
     },
     {
@@ -354,7 +354,7 @@
   ],
   "metadata": {
     "colab": {
-      "name": "GoogLeNet implementation in Keras"
+      "name": "GoogLeNet v1 in Keras"
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/googlenet/keras/README.md
+++ b/googlenet/keras/README.md
@@ -14,6 +14,6 @@ Implementation notes for v1:
 [colab-badge]: https://colab.research.google.com/assets/colab-badge.svg
 [binder-badge]: https://static.mybinder.org/badge_logo.svg
 
-[github-basic]: GoogLeNet_implementation_in_Keras.ipynb
-[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/googlenet/keras/GoogLeNet_implementation_in_Keras.ipynb
-[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=googlenet/keras/GoogLeNet_implementation_in_Keras.ipynb
+[github-basic]: GoogLeNet_v1.ipynb
+[colab-basic]: https://colab.research.google.com/github/mbrukman/reimplementing-ml-papers/blob/main/googlenet/keras/GoogLeNet_v1.ipynb
+[binder-basic]: https://mybinder.org/v2/gh/mbrukman/reimplementing-ml-papers/main?filepath=googlenet/keras/GoogLeNet_v1.ipynb


### PR DESCRIPTION
Now that it's in a `keras` subdirectory, it doesn't need to have the long name or include "Keras" in the filename, as it's clear from the path.